### PR TITLE
Replace `std::codecvt` by `MultiByteToWideChar` due to deprecation

### DIFF
--- a/source/utils/path.cpp
+++ b/source/utils/path.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 
 #include <algorithm>
+#include <cassert>
 #include <fstream>
 #include <iterator>
 #include <sstream>
@@ -230,13 +231,14 @@ const std::string &path::string() const
 std::wstring path::wstring() const
 {
     const std::string &path_str = string();
-    int size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path_str.c_str(), static_cast<int>(path_str.length()), nullptr, 0);
+    const int allocated_size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path_str.c_str(), static_cast<int>(path_str.length()), nullptr, 0);
 
-    if (size > 0)
+    if (allocated_size > 0)
     {
-        std::wstring path_converted(size, L'\0');
+        std::wstring path_converted(allocated_size, L'\0');
         // Note: const_cast is NOT necessary in C++17 and newer!
-        size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path_str.c_str(), static_cast<int>(path_str.length()), const_cast<wchar_t *>(path_converted.data()), size);
+        const int actual_size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path_str.c_str(), static_cast<int>(path_str.length()), &path_converted.at(0), allocated_size);
+        assert(allocated_size == actual_size); // unless a serious error happened, this MUST always be true!
         return path_converted;
     }
     else

--- a/source/utils/path.cpp
+++ b/source/utils/path.cpp
@@ -236,7 +236,6 @@ std::wstring path::wstring() const
     if (allocated_size > 0)
     {
         std::wstring path_converted(allocated_size, L'\0');
-        // Note: const_cast is NOT necessary in C++17 and newer!
         const int actual_size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path_str.c_str(), static_cast<int>(path_str.length()), &path_converted.at(0), allocated_size);
         assert(allocated_size == actual_size); // unless a serious error happened, this MUST always be true!
         return path_converted;

--- a/tests/utils/path_test_suite.cpp
+++ b/tests/utils/path_test_suite.cpp
@@ -23,10 +23,10 @@
 
 #include <iostream>
 
+#include <xlnt/utils/path.hpp>
 #include <helpers/path_helper.hpp>
 #include <helpers/temporary_file.hpp>
 #include <helpers/test_suite.hpp>
-#include <xlnt/utils/path.hpp>
 
 class path_test_suite : public test_suite
 {
@@ -34,20 +34,33 @@ public:
     path_test_suite()
     {
         register_test(test_exists);
+#ifdef _MSC_VER
+        register_test(test_msvc_empty_path_wide);
+#endif
     }
 
-	void test_exists()
-	{
-		temporary_file temp;
+    void test_exists()
+    {
+        temporary_file temp;
 
-		if (temp.get_path().exists())
-		{
-			path_helper::delete_file(temp.get_path());
-		}
+        if (temp.get_path().exists())
+        {
+            path_helper::delete_file(temp.get_path());
+        }
 
-		xlnt_assert(!temp.get_path().exists());
-		std::ofstream stream(temp.get_path().string());
-		xlnt_assert(temp.get_path().exists());
-	}
+        xlnt_assert(!temp.get_path().exists());
+        std::ofstream stream(temp.get_path().string());
+        xlnt_assert(temp.get_path().exists());
+    }
+
+#ifdef _MSC_VER
+    void test_msvc_empty_path_wide()
+    {
+        xlnt::path empty_path;
+        std::wstring path_wide;
+        xlnt_assert_throws_nothing(path_wide = empty_path.wstring());
+        xlnt_assert(path_wide.empty());
+    }
+#endif
 };
 static path_test_suite x;


### PR DESCRIPTION
Replace `std::codecvt` for UTF-8 to UTF-16 conversions under Windows by `MultiByteToWideChar` provided by the Windows API, as the `std::codecvt` conversions are deprecated since C++17 and removed in C++26.