### PR TITLE
Fix stylesheet bloat

### DIFF
--- a/source/detail/implementations/stylesheet.hpp
+++ b/source/detail/implementations/stylesheet.hpp
@@ -470,11 +470,21 @@ struct stylesheet
     format_impl *find_or_create_with(format_impl *pattern, const number_format &new_number_format, optional<bool> applied)
     {
         format_impl new_format = *pattern;
-        if (new_number_format.id() >= 164)
+        if (new_number_format.has_id() && new_number_format.id() < 164)
         {
-            find_or_add(number_formats, new_number_format);
+            new_format.number_format_id = new_number_format.id();
         }
-        new_format.number_format_id = new_number_format.id();
+        else
+        {
+            auto iter = std::find(number_formats.begin(), number_formats.end(), new_number_format);
+            if (iter == number_formats.end())
+            {
+                number_format new_item(new_number_format);
+                new_item.id(next_custom_number_format_id());
+                iter = number_formats.emplace(number_formats.end(), new_item);
+            }
+            new_format.number_format_id = iter->id();
+        }
         new_format.number_format_applied = applied;
         if (pattern->references == 0)
         {

--- a/source/styles/format.cpp
+++ b/source/styles/format.cpp
@@ -151,15 +151,7 @@ xlnt::number_format format::number_format() const
 
 format format::number_format(const xlnt::number_format &new_number_format, optional<bool> applied)
 {
-    auto copy = new_number_format;
-
-    if (!copy.has_id())
-    {
-        copy.id(d_->parent->next_custom_number_format_id());
-        d_->parent->number_formats.push_back(copy);
-    }
-
-    d_ = d_->parent->find_or_create_with(d_, copy, applied);
+    d_ = d_->parent->find_or_create_with(d_, new_number_format, applied);
     return format(d_);
 }
 


### PR DESCRIPTION
Greetings to all.
This change corrects the insertion of identical number formats with different identifiers.

styles.xml before:

```xml
  <numFmts count="7440">
    <numFmt numFmtId="164" formatCode="yyyy-mm-dd h:mm:ss"/>
    <numFmt numFmtId="165" formatCode="dd/mm/yyyy\ h:mm:ss"/>
    <numFmt numFmtId="166" formatCode="yyyy-mm-dd h:mm:ss"/>
    <numFmt numFmtId="167" formatCode="dd/mm/yyyy\ h:mm:ss"/>
...
```

styles.xml after:

```xml
<numFmts count="1">
        <numFmt numFmtId="164"  formatCode="DD-MM-YYYY hh:mm:ss" />
    </numFmts>
```