### PR TITLE
Support coveralls for PR from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,12 @@ setup: true
 orbs:
   continuation: circleci/continuation@1
 
+# parameters are automatically forwarded to continuation
+parameters:
+  run-build:
+    type: boolean
+    default: true
+
 jobs:
   setup:
     docker:

--- a/.circleci/continue_config_in.yml
+++ b/.circleci/continue_config_in.yml
@@ -2,6 +2,12 @@ version: 2.1
 
 # setup.sh replaces the following patterns:
 # - PLACEHOLDER_IMAGE(*): replaced by the Docker image tagged name built for the .circleci/*.Dockerfile
+# - HAS_COVERALLS: replaced by true / false depending on the availability of coveralls
+
+parameters:
+  run-build:
+    type: boolean
+    default: true
 
 jobs:
   build-gcc:
@@ -164,6 +170,7 @@ jobs:
 
 workflows:
   build:
+    when: << pipeline.parameters.run-build >>
     jobs:
       - build-gcc:
           name: tests-gcc7-cmake3.2
@@ -197,18 +204,6 @@ workflows:
               static:
                 - "ON"
                 - "OFF"
-          filters:
-            branches:
-              ignore: gh-pages
-
-      - build-gcc:
-          name: samples-benchmarks-coverage-gcc
-          cxx-ver: "11"
-          build-type: Debug
-          static: "ON"
-          samples: "ON"
-          benchmarks: "ON"
-          coverage: "ON"
           filters:
             branches:
               ignore: gh-pages
@@ -257,3 +252,18 @@ workflows:
           filters:
             branches:
               only: master
+
+  coveralls:
+    when: HAS_COVERALLS
+    jobs:
+      - build-gcc:
+          name: samples-benchmarks-coverage-gcc
+          cxx-ver: "11"
+          build-type: Debug
+          static: "ON"
+          samples: "ON"
+          benchmarks: "ON"
+          coverage: "ON"
+          filters:
+            branches:
+              ignore: gh-pages

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -38,11 +38,22 @@ setupDocker ()
     REPLACE_REGEX+="${REPLACE_REGEX} -e s#PLACEHOLDER_IMAGE($1)#${IMAGE}#"
 }
 
+checkCoveralls ()
+{
+    if [ -n "${COVERALLS_REPO_TOKEN}" ]; then
+        REPLACE_REGEX+="${REPLACE_REGEX} -e s#HAS_COVERALLS#true#"
+    else
+        REPLACE_REGEX+="${REPLACE_REGEX} -e s#HAS_COVERALLS#false#"
+    fi
+}
+
 main ()
 {
     for filename in *.Dockerfile; do
         setupDocker $(basename "$filename" .Dockerfile)
     done
+
+    checkCoveralls
 
     sed ${REPLACE_REGEX} continue_config_in.yml > continue_config.yml
 }


### PR DESCRIPTION
Coveralls credentials are not exposed for PR from forks for security reasons (i.e. exposing secrets by altering the CircleCI configuration).

Coveralls can be run afterwards by an authorised user by manually triggering the default pipeline for the PR inside CircleCI. This should only be done AFTER reviewing the PR. The parameter `run-build = false` can be set to avoid rerunning all the tests.