### PR TITLE
Fix read/write microbenchmark and added production implementation to benchmark

### DIFF
--- a/.circleci/continue_config_in.yml
+++ b/.circleci/continue_config_in.yml
@@ -18,6 +18,9 @@ jobs:
       benchmarks:
         default: "OFF"
         type: string
+      micro-benchmarks:
+        default: "OFF"
+        type: string
       build-type:
         default: Release
         type: string
@@ -39,7 +42,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init --recursive
-      - run: cmake -D XLNT_ALL_WARNINGS_AS_ERRORS=ON -D XLNT_CXX_LANG=<< parameters.cxx-ver >> -D STATIC=<< parameters.static >> -D BENCHMARKS=<< parameters.benchmarks >> -D TESTS=ON -D SAMPLES=<< parameters.samples >> -D COVERAGE=<< parameters.coverage >> -D CMAKE_BUILD_TYPE=<< parameters.build-type >> .
+      - run: cmake -D XLNT_ALL_WARNINGS_AS_ERRORS=ON -D XLNT_CXX_LANG=<< parameters.cxx-ver >> -D STATIC=<< parameters.static >> -D BENCHMARKS=<< parameters.benchmarks >> -D XLNT_MICROBENCH_ENABLED=<< parameters.micro-benchmarks >> -D TESTS=ON -D SAMPLES=<< parameters.samples >> -D COVERAGE=<< parameters.coverage >> -D CMAKE_BUILD_TYPE=<< parameters.build-type >> .
       - run: cmake --build . -- -j2
       - run: ./tests/xlnt.test
       - when:
@@ -55,6 +58,12 @@ jobs:
           steps:
             - run: ./benchmarks/benchmark-styles
             - run: ./benchmarks/benchmark-writer
+            - run: ./benchmarks/benchmark-spreadsheet-load
+      - when:
+          condition:
+            equal: ["ON", << parameters.micro-benchmarks >>]
+          steps:
+            - run: ./benchmarks/microbenchmarks/xlnt_ubench
       - when:
           condition:
             equal: ["ON", << parameters.coverage >>]
@@ -204,6 +213,17 @@ workflows:
               static:
                 - "ON"
                 - "OFF"
+          filters:
+            branches:
+              ignore: gh-pages
+
+      - build-gcc:
+          name: benchmarks-gcc
+          image: PLACEHOLDER_IMAGE(gcc14_cmake3.30.3)
+          cxx-ver: "17"
+          build-type: Release
+          benchmarks: "ON"
+          micro-benchmarks: "ON"
           filters:
             branches:
               ignore: gh-pages

--- a/benchmarks/microbenchmarks/CMakeLists.txt
+++ b/benchmarks/microbenchmarks/CMakeLists.txt
@@ -27,6 +27,8 @@ FetchContent_MakeAvailable(googlebenchmark)
 
 
 add_executable(xlnt_ubench)
+target_include_directories(xlnt_ubench
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../source)
 target_sources(xlnt_ubench
 	PRIVATE
 		string_to_double.cpp

--- a/benchmarks/microbenchmarks/CMakeLists.txt
+++ b/benchmarks/microbenchmarks/CMakeLists.txt
@@ -14,7 +14,7 @@ include(FetchContent)
 FetchContent_Declare(
 	googlebenchmark
 	GIT_REPOSITORY 	https://github.com/google/benchmark
-	GIT_TAG			v1.5.0
+	GIT_TAG			v1.8.5
 )
 # download if not already present
 FetchContent_GetProperties(googlebenchmark)

--- a/benchmarks/microbenchmarks/double_to_string.cpp
+++ b/benchmarks/microbenchmarks/double_to_string.cpp
@@ -8,6 +8,7 @@
 #include <random>
 #include <sstream>
 #include <xlnt/utils/numeric.hpp>
+#include <detail/environment.hpp>
 
 namespace {
 
@@ -200,7 +201,7 @@ BENCHMARK_F(RandFloats, string_from_double_production)
     }
 }
 
-#if defined(_MSC_VER) || __cplusplus >= 201703L
+#if XLNT_HAS_FEATURE(TO_CHARS)
 #include <charconv>
 BENCHMARK_F(RandFloats, string_from_double_std_to_chars)
 (benchmark::State &state)

--- a/benchmarks/microbenchmarks/double_to_string.cpp
+++ b/benchmarks/microbenchmarks/double_to_string.cpp
@@ -7,6 +7,7 @@
 #include <locale>
 #include <random>
 #include <sstream>
+#include <xlnt/utils/numeric.hpp>
 
 namespace {
 
@@ -23,15 +24,17 @@ class RandomFloats : public benchmark::Fixture
     const char *locale_str = nullptr;
 
 public:
-    void SetUp(const ::benchmark::State &state)
+    void SetUp(::benchmark::State &state)
     {
+        locale_str = setlocale(LC_ALL, nullptr);
         if (Decimal_Locale)
         {
-            locale_str = setlocale(LC_ALL, "C");
+            setlocale(LC_ALL, "C");
         }
         else
         {
-            locale_str = setlocale(LC_ALL, "de-DE");
+            if (setlocale(LC_ALL, "de_DE") == nullptr)
+                state.SkipWithError("de_DE locale not installed");
         }
         std::random_device rd; // obtain a seed for the random number engine
         std::mt19937 gen(rd());
@@ -73,13 +76,23 @@ std::string serialize_number_to_string(double num)
     return ss.str();
 }
 
-class number_serialiser
+struct number_serialiser_production
+{
+    std::string serialise(double d)
+    {
+        return serializer.serialise(d);
+    }
+
+    xlnt::detail::number_serialiser serializer;
+};
+
+class number_serialiser_stream
 {
     static constexpr int Excel_Digit_Precision = 15; //sf
     std::ostringstream ss;
 
 public:
-    explicit number_serialiser()
+    explicit number_serialiser_stream()
     {
         ss.precision(Excel_Digit_Precision);
         ss.imbue(std::locale("C"));
@@ -111,7 +124,7 @@ class number_serialiser_mk2
 
 public:
     explicit number_serialiser_mk2()
-        : should_convert_comma(std::use_facet<std::numpunct<char>>(std::locale{}).decimal_point() == ',')
+        : should_convert_comma(localeconv()->decimal_point[0] == ',')
     {
     }
 
@@ -144,7 +157,7 @@ BENCHMARK_F(RandFloats, string_from_double_sstream)
 BENCHMARK_F(RandFloats, string_from_double_sstream_cached)
 (benchmark::State &state)
 {
-    number_serialiser ser;
+    number_serialiser_stream ser;
     while (state.KeepRunning())
     {
         benchmark::DoNotOptimize(
@@ -176,9 +189,18 @@ BENCHMARK_F(RandFloats, string_from_double_snprintf_fixed)
     }
 }
 
-// locale names are different between OS's, and std::from_chars is only complete in MSVC
-#ifdef _MSC_VER
+BENCHMARK_F(RandFloats, string_from_double_production)
+(benchmark::State &state)
+{
+    number_serialiser_production ser;
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(
+            ser.serialise(get_rand()));
+    }
+}
 
+#if defined(_MSC_VER) || __cplusplus >= 201703L
 #include <charconv>
 BENCHMARK_F(RandFloats, string_from_double_std_to_chars)
 (benchmark::State &state)
@@ -192,6 +214,7 @@ BENCHMARK_F(RandFloats, string_from_double_std_to_chars)
             std::string(buf, result.ptr));
     }
 }
+#endif
 
 BENCHMARK_F(RandFloatsComma, string_from_double_snprintf_fixed_comma)
 (benchmark::State &state)
@@ -204,4 +227,13 @@ BENCHMARK_F(RandFloatsComma, string_from_double_snprintf_fixed_comma)
     }
 }
 
-#endif
+BENCHMARK_F(RandFloatsComma, string_from_double_production_comma)
+(benchmark::State &state)
+{
+    number_serialiser_production ser;
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(
+            ser.serialise(get_rand()));
+    }
+}

--- a/benchmarks/microbenchmarks/string_to_double.cpp
+++ b/benchmarks/microbenchmarks/string_to_double.cpp
@@ -8,6 +8,7 @@
 #include <random>
 #include <sstream>
 #include <xlnt/utils/numeric.hpp>
+#include <detail/environment.hpp>
 
 namespace {
 
@@ -205,7 +206,7 @@ BENCHMARK_F(RandFloatStrs, double_from_string_production)
     }
 }
 
-#if defined(_MSC_VER) || __cplusplus >= 201703L
+#if XLNT_HAS_FEATURE(TO_CHARS)
 #include <charconv>
 BENCHMARK_F(RandFloatStrs, double_from_string_std_from_chars)
 (benchmark::State &state)

--- a/benchmarks/microbenchmarks/string_to_double.cpp
+++ b/benchmarks/microbenchmarks/string_to_double.cpp
@@ -7,6 +7,7 @@
 #include <locale>
 #include <random>
 #include <sstream>
+#include <xlnt/utils/numeric.hpp>
 
 namespace {
 
@@ -23,16 +24,10 @@ class RandomFloatStrs : public benchmark::Fixture
     const char *locale_str = nullptr;
 
 public:
-    void SetUp(const ::benchmark::State &state)
+    void SetUp(::benchmark::State &state)
     {
-        if (Decimal_Locale)
-        {
-            locale_str = setlocale(LC_ALL, "C");
-        }
-        else
-        {
-            locale_str = setlocale(LC_ALL, "de-DE");
-        }
+        locale_str = setlocale(LC_ALL, nullptr);
+        setlocale(LC_ALL, "C");
         std::random_device rd; // obtain a seed for the random number engine
         std::mt19937 gen(rd());
         // doing full range is stupid (<double>::min/max()...), it just ends up generating very large numbers
@@ -46,6 +41,15 @@ public:
             char buf[16];
             snprintf(buf, 16, "%.15f", d);
             inputs.push_back(std::string(buf));
+        }
+        if (Decimal_Locale)
+        {
+            locale_str = setlocale(LC_ALL, "C");
+        }
+        else
+        {
+            if (setlocale(LC_ALL, "de_DE") == nullptr)
+                state.SkipWithError("de_DE locale not installed");
         }
     }
 
@@ -63,11 +67,21 @@ public:
     }
 };
 
+struct number_converter_production
+{
+    double stold(const std::string &s)
+    {
+        return serializer.deserialise(s);
+    }
+
+    xlnt::detail::number_serialiser serializer;
+};
+
 // method used by xlsx_consumer.cpp in commit - ba01de47a7d430764c20ec9ac9600eec0eb38bcf
 // std::istringstream with the locale set to "C"
-struct number_converter
+struct number_converter_stream
 {
-    number_converter()
+    number_converter_stream()
     {
         stream.imbue(std::locale("C"));
     }
@@ -89,7 +103,7 @@ struct number_converter
 struct number_converter_mk2
 {
     explicit number_converter_mk2()
-        : should_convert_to_comma(std::use_facet<std::numpunct<char>>(std::locale{}).decimal_point() == ',')
+        : should_convert_to_comma(localeconv()->decimal_point[0] == ',')
     {
     }
 
@@ -135,7 +149,7 @@ using RandFloatCommaStrs = RandomFloatStrs<false>;
 BENCHMARK_F(RandFloatStrs, double_from_string_sstream)
 (benchmark::State &state)
 {
-    number_converter converter;
+    number_converter_stream converter;
     while (state.KeepRunning())
     {
         benchmark::DoNotOptimize(
@@ -180,9 +194,18 @@ BENCHMARK_F(RandFloatStrs, double_from_string_strtod_fixed_const_ref)
     }
 }
 
-// locale names are different between OS's, and std::from_chars is only complete in MSVC
-#ifdef _MSC_VER
+BENCHMARK_F(RandFloatStrs, double_from_string_production)
+(benchmark::State &state)
+{
+    number_converter_production converter;
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(
+            converter.stold(get_rand()));
+    }
+}
 
+#if defined(_MSC_VER) || __cplusplus >= 201703L
 #include <charconv>
 BENCHMARK_F(RandFloatStrs, double_from_string_std_from_chars)
 (benchmark::State &state)
@@ -195,6 +218,7 @@ BENCHMARK_F(RandFloatStrs, double_from_string_std_from_chars)
             std::from_chars(input.data(), input.data() + input.size(), output));
     }
 }
+#endif
 
 // not using the standard "C" locale with '.' seperator
 BENCHMARK_F(RandFloatCommaStrs, double_from_string_strtod_fixed_comma_ref)
@@ -220,4 +244,13 @@ BENCHMARK_F(RandFloatCommaStrs, double_from_string_strtod_fixed_comma_const_ref)
     }
 }
 
-#endif
+BENCHMARK_F(RandFloatCommaStrs, double_from_string_production_comma)
+(benchmark::State &state)
+{
+    number_converter_production converter;
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(
+            converter.stold(get_rand()));
+    }
+}

--- a/source/detail/environment.hpp
+++ b/source/detail/environment.hpp
@@ -42,7 +42,7 @@
 #define XLNT_CPP_23 202302L
 
 /// <summary>
-/// Returns whether the cpp version `version` is supported by the current build configuration.
+/// Returns whether the C++ version `version` is supported by the current build configuration.
 /// </summary>
 /// <seealso cref="XLNT_CPP_11">
 /// <seealso cref="XLNT_CPP_14">
@@ -56,6 +56,18 @@
 #else
   #define XLNT_DETAIL_FEATURE_TO_CHARS -1
 #endif
+
+#define XLNT_C_11 201112L
+#define XLNT_C_17 201710L
+#define XLNT_C_23 202311L
+
+/// <summary>
+/// Returns whether the C version `version` is supported by the current build configuration.
+/// </summary>
+/// <seealso cref="XLNT_C_11">
+/// <seealso cref="XLNT_C_17">
+/// <seealso cref="XLNT_C_23">
+#define XLNT_HAS_C_VERSION(version) (1/version == 1/version && XLNT_C_VERSION >= version)
 
 // If you get a division by zero error, you probably misspelled the feature name.
 // Developer note: XLNT_DETAIL_FEATURE_##feature should be set to

--- a/source/detail/environment.hpp
+++ b/source/detail/environment.hpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 xlnt-community
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE
+//
+// @license: http://www.opensource.org/licenses/mit-license.php
+// @author: see AUTHORS file
+
+#pragma once
+
+// Unfortunately, the macro __cplusplus does not report the correct version under Visual Studio unless /Zc:__cplusplus is used during compilation.
+// Source: https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170
+// In order to have proper feature testing for C++ features that don't have feature test macros, but also to avoid forcing others
+// to configure their compiler properly, we'll need to define our own macro.
+#ifndef XLNT_CPP_VERSION
+  #if defined(_MSVC_LANG) && _MSVC_LANG > __cplusplus // take the larger one of the two (Microsoft does the same in the MSVC STL)
+    #define XLNT_CPP_VERSION _MSVC_LANG
+  #else
+    #define XLNT_CPP_VERSION __cplusplus
+  #endif
+#endif
+
+#define XLNT_CPP_11 201103L
+#define XLNT_CPP_14 201402L
+#define XLNT_CPP_17 201703L
+#define XLNT_CPP_20 202002L
+#define XLNT_CPP_23 202302L
+
+/// <summary>
+/// Returns whether the cpp version `version` is supported by the current build configuration.
+/// </summary>
+/// <seealso cref="XLNT_CPP_11">
+/// <seealso cref="XLNT_CPP_14">
+/// <seealso cref="XLNT_CPP_17">
+/// <seealso cref="XLNT_CPP_20">
+/// <seealso cref="XLNT_CPP_23">
+#define XLNT_HAS_CPP_VERSION(version) (1/version == 1/version && XLNT_CPP_VERSION >= version)
+
+#if XLNT_HAS_CPP_VERSION(XLNT_CPP_17)
+  #define XLNT_DETAIL_FEATURE_TO_CHARS 1
+#else
+  #define XLNT_DETAIL_FEATURE_TO_CHARS -1
+#endif
+
+// If you get a division by zero error, you probably misspelled the feature name.
+// Developer note: XLNT_DETAIL_FEATURE_##feature should be set to
+//    1: if feature is supported
+//    -1: if the feature is not supported
+/// <summary>
+/// Returns whether the `feature` is supported by the current build configuration.
+/// </summary>
+/// Currently, the following features could be tested:
+///  - TO_CHARS: returns whether compliant std::from_chars and std::to_chars implementations are available
+#define XLNT_HAS_FEATURE(feature) (1/XLNT_DETAIL_FEATURE_##feature == 1)


### PR DESCRIPTION
RandomFloats(Strs)::SetUp: setlocale returns the currently set locale. To restore the old locale after the benchmark has run, the current locale should be first queried (by passinga nullptr as the second argument).
RandomFloats(Strs)::SetUp: abort the test that depend on the de_DE locale if this locale is not available to avoid producing irrelevant test results.

RandomFloatStrs: should always generate strings with a "." as the decimal separator, as xlsx files always use this as well, regardless of the current locale.

number_serialiser_mk2: `std::use_facet<std::numpunct<char>>(std::locale{}).decimal_point() == ','` always returns false, as it checks the decimal point of the "C" locale.

number_serialiser_production: uses the serialiser that is currently used by the xlnt library. Usefull to compare the currently used implementation with possible alternatives and/or monitor regression.

Enable `std::from_chars` / `std::to_chars` on all platforms if C++17 is supported.

Enable benchmarks using comma as decimal separator on all platforms. Why was this only enabled on MSVC?

Added (micro)benchmarking of release builds to CircleCI to allow monitoring regression.