### PR TITLE
Fix coverage report for inline/templated functions

### DIFF
--- a/.circleci/continue_config_in.yml
+++ b/.circleci/continue_config_in.yml
@@ -80,7 +80,8 @@ jobs:
           steps:
             - run: apt-get update -y
             - run: apt-get install -y --no-install-recommends lcov
-            - run: lcov --directory source/CMakeFiles/xlnt.dir --capture --output-file coverage.info --base-directory source --no-external
+            - run: lcov --directory . --capture --output-file coverage.info --base-directory . --no-external
+            - run: lcov --extract coverage.info "$PWD/include/*" "$PWD/source/*" --output-file coverage.info
             - run: curl -sL https://coveralls.io/coveralls-linux.tar.gz | tar -xz && ./coveralls report coverage.info
 
   docs-build:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ set(HELPERS ${HELPERS_HEADERS} ${HELPERS_SOURCES})
 set(RUNNER ${CMAKE_CURRENT_SOURCE_DIR}/runner.cpp)
 
 if(COVERAGE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
 


### PR DESCRIPTION
Added include directory to coverage report

Generate coverage data for the test project as it contains relevant data about the inline/templated functions.