### PR TITLE
Add support for C++20 and C++23, and experimental support for C++26

### DIFF
--- a/.circleci/continue_config_in.yml
+++ b/.circleci/continue_config_in.yml
@@ -324,7 +324,7 @@ workflows:
     jobs:
       - build-gcc:
           name: samples-benchmarks-coverage-gcc
-          cxx-ver: "11"
+          cxx-ver: "23"
           build-type: Debug
           static: "ON"
           samples: "ON"

--- a/.circleci/continue_config_in.yml
+++ b/.circleci/continue_config_in.yml
@@ -234,7 +234,7 @@ workflows:
             parameters:
               cxx-ver:
                 - "11"
-                - "17"
+                - "23"
               build-type:
                 - Release
                 - Debug
@@ -248,8 +248,8 @@ workflows:
               # Exclude {static: ON, skip-internal-tests: ON} subset
               - {static: "ON", skip-internal-tests: "ON", cxx-ver: "11", build-type: Debug}
               - {static: "ON", skip-internal-tests: "ON", cxx-ver: "11", build-type: Release}
-              - {static: "ON", skip-internal-tests: "ON", cxx-ver: "17", build-type: Debug}
-              - {static: "ON", skip-internal-tests: "ON", cxx-ver: "17", build-type: Release}
+              - {static: "ON", skip-internal-tests: "ON", cxx-ver: "23", build-type: Debug}
+              - {static: "ON", skip-internal-tests: "ON", cxx-ver: "23", build-type: Release}
           filters:
             branches:
               ignore: gh-pages

--- a/.circleci/continue_config_in.yml
+++ b/.circleci/continue_config_in.yml
@@ -324,6 +324,7 @@ workflows:
     jobs:
       - build-gcc:
           name: samples-benchmarks-coverage-gcc
+          image: PLACEHOLDER_IMAGE(gcc_cmake_latest)
           cxx-ver: "23"
           build-type: Debug
           static: "ON"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(COMBINED_PROJECT TRUE)
 option(STATIC "Set to ON to build xlnt as a static library instead of a shared library" OFF)
 
 # C++ language standard to use
-set(XLNT_CXX_VALID_LANGS 11 14 17)
+set(XLNT_CXX_VALID_LANGS 11 14 17 20 23 26)
 set(XLNT_CXX_LANG "14" CACHE STRING "C++ language features to compile with")
 # enumerate allowed values for cmake gui
 set_property(CACHE XLNT_CXX_LANG PROPERTY STRINGS ${XLNT_CXX_VALID_LANGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ list(FIND XLNT_CXX_VALID_LANGS ${XLNT_CXX_LANG} index)
 if(index EQUAL -1)
     message(FATAL_ERROR "XLNT_CXX_LANG must be one of ${XLNT_CXX_VALID_LANGS}")
 endif()
+if(XLNT_CXX_LANG EQUAL 26)
+    message(WARNING "Support for C++26 in XLNT is still experimental. Please report any C++26-related warnings or errors!")
+endif()
 
 # C language standard to use
 set(XLNT_C_VALID_LANGS 99 11 17 23)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.1...3.31)
 project(xlnt.benchmarks)
 
-# Require C++11 compiler
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD ${XLNT_CXX_LANG})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD ${XLNT_C_LANG})
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CXX_EXTENSIONS OFF)
 
 if(NOT COMBINED_PROJECT)
   # Include xlnt library
@@ -34,8 +36,11 @@ foreach(BENCHMARK_SOURCE IN ITEMS ${BENCHMARK_SOURCES})
   # Need to use some test helpers
   target_include_directories(${BENCHMARK_EXECUTABLE}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../tests)
+  # Some helpers also need further internal includes
+  target_include_directories(${BENCHMARK_EXECUTABLE}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../source)
   target_compile_definitions(${BENCHMARK_EXECUTABLE}
-    PRIVATE XLNT_BENCHMARK_DATA_DIR=${XLNT_BENCHMARK_DATA_DIR})
+    PRIVATE XLNT_BENCHMARK_DATA_DIR="${XLNT_BENCHMARK_DATA_DIR}")
 
   if (XLNT_USE_LOCALE_COMMA_DECIMAL_SEPARATOR)
     target_compile_definitions(${BENCHMARK_EXECUTABLE} PRIVATE XLNT_USE_LOCALE_COMMA_DECIMAL_SEPARATOR=1)

--- a/benchmarks/microbenchmarks/CMakeLists.txt
+++ b/benchmarks/microbenchmarks/CMakeLists.txt
@@ -35,7 +35,13 @@ target_sources(xlnt_ubench
 		double_to_string.cpp
 )
 target_link_libraries(xlnt_ubench benchmark_main xlnt)
-target_compile_features(xlnt_ubench PRIVATE cxx_std_17)
+# Require C++17 for benchmarking std::to_chars and std::from_chars
+if (XLNT_CXX_LANG LESS 17)
+  target_compile_features(xlnt_ubench PRIVATE cxx_std_17)
+else()
+  target_compile_features(xlnt_ubench PRIVATE cxx_std_${XLNT_CXX_LANG})
+endif()
+target_compile_features(xlnt_ubench PRIVATE c_std_${XLNT_C_LANG})
 
 if (XLNT_USE_LOCALE_COMMA_DECIMAL_SEPARATOR)
   target_compile_definitions(xlnt_ubench PRIVATE XLNT_USE_LOCALE_COMMA_DECIMAL_SEPARATOR=1)

--- a/benchmarks/microbenchmarks/double_to_string.cpp
+++ b/benchmarks/microbenchmarks/double_to_string.cpp
@@ -9,7 +9,7 @@
 #include <random>
 #include <sstream>
 #include <detail/serialization/serialisation_helpers.hpp>
-#include <detail/utils/features.hpp>
+#include <xlnt/internal/features.hpp>
 
 namespace {
 

--- a/benchmarks/microbenchmarks/string_to_double.cpp
+++ b/benchmarks/microbenchmarks/string_to_double.cpp
@@ -9,7 +9,7 @@
 #include <random>
 #include <sstream>
 #include <detail/serialization/serialisation_helpers.hpp>
-#include <detail/utils/features.hpp>
+#include <xlnt/internal/features.hpp>
 
 namespace {
 

--- a/include/xlnt/internal/features.hpp
+++ b/include/xlnt/internal/features.hpp
@@ -38,6 +38,22 @@
   #include <version>
 #endif
 
+// If you get a division by zero error, you probably misspelled the feature name.
+// Developer note: XLNT_DETAIL_FEATURE_##feature should be set to
+//    1: if feature is supported
+//    -1: if the feature is not supported
+/// <summary>
+/// Returns whether the `feature` is supported by the current build configuration.
+/// </summary>
+/// Currently, the following features could be tested:
+///  - TO_CHARS: returns whether compliant std::from_chars and std::to_chars implementations are available
+///  - STRING_VIEW: returns whether compliant std::string_view, std::wstring_view, std::u16string_view and
+///                 std::u32string_view implementations are available (note: std::u8string_view is part
+///                 of C++20 - see U8_STRING_VIEW below)
+///  - FILESYSTEM: returns whether a compliant std::filesystem implementations is available
+///  - U8_STRING_VIEW: returns whether a compliant std::u8string_view implementation is available
+#define XLNT_HAS_FEATURE(feature) (1/XLNT_DETAIL_FEATURE_##feature == 1)
+
 // Note: the first check ensures that a compiler partially implementing C++17 but implementing std::to_chars
 // would be detected correctly, as long as the C++20 feature test macros are implemented. The second check
 // ensures that a fully implemented C++17 compiler would be detected as well.
@@ -59,19 +75,8 @@
   #define XLNT_DETAIL_FEATURE_FILESYSTEM -1
 #endif
 
-#if XLNT_DETAIL_FEATURE_STRING_VIEW == 1 && defined(__cpp_lib_char8_t)
+#if XLNT_HAS_FEATURE(STRING_VIEW) && defined(__cpp_lib_char8_t)
   #define XLNT_DETAIL_FEATURE_U8_STRING_VIEW 1
 #else
   #define XLNT_DETAIL_FEATURE_U8_STRING_VIEW -1
 #endif
-
-// If you get a division by zero error, you probably misspelled the feature name.
-// Developer note: XLNT_DETAIL_FEATURE_##feature should be set to
-//    1: if feature is supported
-//    -1: if the feature is not supported
-/// <summary>
-/// Returns whether the `feature` is supported by the current build configuration.
-/// </summary>
-/// Currently, the following features could be tested:
-///  - TO_CHARS: returns whether compliant std::from_chars and std::to_chars implementations are available
-#define XLNT_HAS_FEATURE(feature) (1/XLNT_DETAIL_FEATURE_##feature == 1)

--- a/include/xlnt/internal/features.hpp
+++ b/include/xlnt/internal/features.hpp
@@ -25,21 +25,44 @@
 
 #include <xlnt/utils/environment.hpp>
 
+// Header detection helper. Available beginning with C++17.
+#ifdef __has_include
+  #define XLNT_HAS_INCLUDE(HEADER_NAME) __has_include(HEADER_NAME)
+#else
+  #define XLNT_HAS_INCLUDE(HEADER_NAME) 0
+#endif
+
 // If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
 // that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
+#if XLNT_HAS_INCLUDE(<version>)
+  #include <version>
 #endif
 
 // Note: the first check ensures that a compiler partially implementing C++17 but implementing std::to_chars
 // would be detected correctly, as long as the C++20 feature test macros are implemented. The second check
 // ensures that a fully implemented C++17 compiler would be detected as well.
-#if __cpp_lib_to_chars >= 201611L || XLNT_HAS_CPP_VERSION(XLNT_CPP_17)
+#if defined(__cpp_lib_to_chars) || XLNT_HAS_CPP_VERSION(XLNT_CPP_17)
   #define XLNT_DETAIL_FEATURE_TO_CHARS 1
 #else
   #define XLNT_DETAIL_FEATURE_TO_CHARS -1
+#endif
+
+#if defined(__cpp_lib_string_view) || XLNT_HAS_CPP_VERSION(XLNT_CPP_17)
+  #define XLNT_DETAIL_FEATURE_STRING_VIEW 1
+#else
+  #define XLNT_DETAIL_FEATURE_STRING_VIEW -1
+#endif
+
+#if defined(__cpp_lib_filesystem) || XLNT_HAS_CPP_VERSION(XLNT_CPP_17)
+  #define XLNT_DETAIL_FEATURE_FILESYSTEM 1
+#else
+  #define XLNT_DETAIL_FEATURE_FILESYSTEM -1
+#endif
+
+#if XLNT_DETAIL_FEATURE_STRING_VIEW == 1 && defined(__cpp_lib_char8_t)
+  #define XLNT_DETAIL_FEATURE_U8_STRING_VIEW 1
+#else
+  #define XLNT_DETAIL_FEATURE_U8_STRING_VIEW -1
 #endif
 
 // If you get a division by zero error, you probably misspelled the feature name.

--- a/include/xlnt/utils/environment.hpp
+++ b/include/xlnt/utils/environment.hpp
@@ -51,6 +51,7 @@
 /// <seealso cref="XLNT_CPP_17">
 /// <seealso cref="XLNT_CPP_20">
 /// <seealso cref="XLNT_CPP_23">
+/// <seealso cref="XLNT_CPP_26">
 #define XLNT_HAS_CPP_VERSION(version) (1/version == 1/version && XLNT_CPP_VERSION >= version)
 
 

--- a/include/xlnt/utils/optional.hpp
+++ b/include/xlnt/utils/optional.hpp
@@ -328,7 +328,7 @@ private:
     }
 
     bool has_value_;
-    typename std::aligned_storage<sizeof(T), alignof(T)>::type storage_;
+    alignas(T) unsigned char storage_[sizeof(T)];
 };
 
 #ifdef XLNT_NOEXCEPT_VALUE_COMPAT

--- a/include/xlnt/utils/path.hpp
+++ b/include/xlnt/utils/path.hpp
@@ -28,6 +28,20 @@
 #include <utility>
 #include <vector>
 
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
+
 #include <xlnt/xlnt_config.hpp>
 
 namespace xlnt {
@@ -57,6 +71,18 @@ public:
     /// Construct a path from a string with an explicit directory seprator.
     /// </summary>
     path(const std::string &path_string, char sep);
+
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// Counstruct a path from a string representing the path.
+    /// </summary>
+    explicit path(std::u8string_view path_string);
+
+    /// <summary>
+    /// Construct a path from a string with an explicit directory seprator.
+    /// </summary>
+    path(std::u8string_view path_string, char sep);
+#endif
 
     // general attributes
 
@@ -166,6 +192,13 @@ public:
     /// Append the provided part to this path and return the result.
     /// </summary>
     path append(const std::string &to_append) const;
+
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// Append the provided part to this path and return the result.
+    /// </summary>
+    path append(std::u8string_view to_append) const;
+#endif
 
     /// <summary>
     /// Append the provided part to this path and return the result.

--- a/include/xlnt/utils/path.hpp
+++ b/include/xlnt/utils/path.hpp
@@ -28,21 +28,12 @@
 #include <utility>
 #include <vector>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
-
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
-#endif
-
 #include <xlnt/xlnt_config.hpp>
+#include <xlnt/internal/features.hpp>
+
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
+#endif
 
 namespace xlnt {
 
@@ -72,7 +63,7 @@ public:
     /// </summary>
     path(const std::string &path_string, char sep);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// Counstruct a path from a string representing the path.
     /// </summary>
@@ -193,7 +184,7 @@ public:
     /// </summary>
     path append(const std::string &to_append) const;
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// Append the provided part to this path and return the result.
     /// </summary>

--- a/include/xlnt/workbook/workbook.hpp
+++ b/include/xlnt/workbook/workbook.hpp
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -32,22 +33,12 @@
 #include <unordered_map>
 #include <vector>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
-
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
-#endif
-
 #include <xlnt/xlnt_config.hpp>
-#include <xlnt/cell/rich_text.hpp>
+#include <xlnt/internal/features.hpp>
+
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
+#endif
 
 namespace xlnt {
 
@@ -154,7 +145,7 @@ public:
     /// </summary>
     workbook(const xlnt::path &file, const std::string &password);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// load the encrpyted xlsx file at path
     /// </summary>
@@ -171,7 +162,7 @@ public:
     /// </summary>
     workbook(std::istream &data, const std::string &password);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// construct the workbook from any data stream where the data is the binary form of an encrypted workbook
     /// </summary>
@@ -507,7 +498,7 @@ public:
     /// </summary>
     void save(std::vector<std::uint8_t> &data, const std::string &password) const;
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// Serializes the workbook into an XLSX file encrypted with the given password
     /// and saves the bytes into byte vector data.
@@ -527,7 +518,7 @@ public:
     /// </summary>
     void save(const std::string &filename, const std::string &password) const;
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// Serializes the workbook into an XLSX file and saves the data into a file
     /// named filename.
@@ -567,7 +558,7 @@ public:
     /// </summary>
     void save(const xlnt::path &filename, const std::string &password) const;
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// Serializes the workbook into an XLSX file encrypted with the given password
     /// and loads the bytes into a file named filename.
@@ -586,7 +577,7 @@ public:
     /// </summary>
     void save(std::ostream &stream, const std::string &password) const;
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// Serializes the workbook into an XLSX file encrypted with the given password
     /// and loads the bytes into the given stream.
@@ -606,7 +597,7 @@ public:
     /// </summary>
     void load(const std::vector<std::uint8_t> &data, const std::string &password);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// Interprets byte vector data as an XLSX file encrypted with the
     /// given password and sets the content of this workbook to match that file.
@@ -626,7 +617,7 @@ public:
     /// </summary>
     void load(const std::string &filename, const std::string &password);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// Interprets file with the given filename as an XLSX file and sets
     /// the content of this workbook to match that file.
@@ -667,7 +658,7 @@ public:
     /// </summary>
     void load(const xlnt::path &filename, const std::string &password);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// Interprets file with the given filename as an XLSX file encrypted with the
     /// given password and sets the content of this workbook to match that file.
@@ -687,7 +678,7 @@ public:
     /// </summary>
     void load(std::istream &stream, const std::string &password);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     /// <summary>
     /// Interprets data in stream as an XLSX file encrypted with the given password
     /// and sets the content of this workbook to match that file.
@@ -971,6 +962,88 @@ private:
     /// Used by static constructor to resolve circular construction dependency.
     /// </summary>
     workbook(detail::workbook_impl *impl);
+
+    /// <summary>
+    /// load the encrpyted xlsx file at path
+    /// </summary>
+    template <typename T>
+    void construct(const xlnt::path &file, const T &password);
+
+    /// <summary>
+    /// construct the workbook from any data stream where the data is the binary form of an encrypted workbook
+    /// </summary>
+    template <typename T>
+    void construct(std::istream &data, const T &password);
+
+    /// <summary>
+    /// Serializes the workbook into an XLSX file encrypted with the given password
+    /// and saves the bytes into byte vector data.
+    /// </summary>
+    template <typename T>
+    void save_internal(std::vector<std::uint8_t> &data, const T &password) const;
+
+    /// <summary>
+    /// Serializes the workbook into an XLSX file and saves the data into a file
+    /// named filename.
+    /// </summary>
+    template <typename T>
+    void save_internal(const T &filename) const;
+
+    /// <summary>
+    /// Serializes the workbook into an XLSX file encrypted with the given password
+    /// and loads the bytes into a file named filename.
+    /// </summary>
+    template <typename T>
+    void save_internal(const T &filename, const T &password) const;
+
+    /// <summary>
+    /// Serializes the workbook into an XLSX file encrypted with the given password
+    /// and loads the bytes into a file named filename.
+    /// </summary>
+    template <typename T>
+    void save_internal(const xlnt::path &filename, const T &password) const;
+
+    /// <summary>
+    /// Serializes the workbook into an XLSX file encrypted with the given password
+    /// and loads the bytes into the given stream.
+    /// </summary>
+    template <typename T>
+    void save_internal(std::ostream &stream, const T &password) const;
+
+    /// <summary>
+    /// Interprets byte vector data as an XLSX file encrypted with the
+    /// given password and sets the content of this workbook to match that file.
+    /// </summary>
+    template <typename T>
+    void load_internal(const std::vector<std::uint8_t> &data, const T &password);
+
+    /// <summary>
+    /// Interprets file with the given filename as an XLSX file and sets
+    /// the content of this workbook to match that file.
+    /// </summary>
+    template <typename T>
+    void load_internal(const T &filename);
+
+    /// <summary>
+    /// Interprets file with the given filename as an XLSX file encrypted with the
+    /// given password and sets the content of this workbook to match that file.
+    /// </summary>
+    template <typename T>
+    void load_internal(const T &filename, const T &password);
+
+    /// <summary>
+    /// Interprets file with the given filename as an XLSX file encrypted with the
+    /// given password and sets the content of this workbook to match that file.
+    /// </summary>
+    template <typename T>
+    void load_internal(const xlnt::path &filename, const T &password);
+
+    /// <summary>
+    /// Interprets data in stream as an XLSX file encrypted with the given password
+    /// and sets the content of this workbook to match that file.
+    /// </summary>
+    template <typename T>
+    void load_internal(std::istream &stream, const T &password);
 
     /// <summary>
     /// Returns a reference to the workbook implementation structure. Provides

--- a/include/xlnt/workbook/workbook.hpp
+++ b/include/xlnt/workbook/workbook.hpp
@@ -27,12 +27,24 @@
 
 #include <functional>
 #include <iterator>
-#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <utility>
 #include <vector>
+
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
 
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/cell/rich_text.hpp>
@@ -142,6 +154,13 @@ public:
     /// </summary>
     workbook(const xlnt::path &file, const std::string &password);
 
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// load the encrpyted xlsx file at path
+    /// </summary>
+    workbook(const xlnt::path &file, std::u8string_view password);
+#endif
+
     /// <summary>
     /// construct the workbook from any data stream where the data is the binary form of a workbook
     /// </summary>
@@ -151,6 +170,13 @@ public:
     /// construct the workbook from any data stream where the data is the binary form of an encrypted workbook
     /// </summary>
     workbook(std::istream &data, const std::string &password);
+
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// construct the workbook from any data stream where the data is the binary form of an encrypted workbook
+    /// </summary>
+    workbook(std::istream &data, std::u8string_view password);
+#endif
 
     /// <summary>
     /// Move constructor. Constructs a workbook from existing workbook, other.
@@ -481,6 +507,14 @@ public:
     /// </summary>
     void save(std::vector<std::uint8_t> &data, const std::string &password) const;
 
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// Serializes the workbook into an XLSX file encrypted with the given password
+    /// and saves the bytes into byte vector data.
+    /// </summary>
+    void save(std::vector<std::uint8_t> &data, std::u8string_view password) const;
+#endif
+
     /// <summary>
     /// Serializes the workbook into an XLSX file and saves the data into a file
     /// named filename.
@@ -492,6 +526,20 @@ public:
     /// and loads the bytes into a file named filename.
     /// </summary>
     void save(const std::string &filename, const std::string &password) const;
+
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// Serializes the workbook into an XLSX file and saves the data into a file
+    /// named filename.
+    /// </summary>
+    void save(std::u8string_view filename) const;
+
+    /// <summary>
+    /// Serializes the workbook into an XLSX file encrypted with the given password
+    /// and loads the bytes into a file named filename.
+    /// </summary>
+    void save(std::u8string_view filename, std::u8string_view password) const;
+#endif
 
 #ifdef _MSC_VER
     /// <summary>
@@ -519,6 +567,14 @@ public:
     /// </summary>
     void save(const xlnt::path &filename, const std::string &password) const;
 
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// Serializes the workbook into an XLSX file encrypted with the given password
+    /// and loads the bytes into a file named filename.
+    /// </summary>
+    void save(const xlnt::path &filename, std::u8string_view password) const;
+#endif
+
     /// <summary>
     /// Serializes the workbook into an XLSX file and saves the data into stream.
     /// </summary>
@@ -529,6 +585,14 @@ public:
     /// and loads the bytes into the given stream.
     /// </summary>
     void save(std::ostream &stream, const std::string &password) const;
+
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// Serializes the workbook into an XLSX file encrypted with the given password
+    /// and loads the bytes into the given stream.
+    /// </summary>
+    void save(std::ostream &stream, std::u8string_view password) const;
+#endif
 
     /// <summary>
     /// Interprets byte vector data as an XLSX file and sets the content of this
@@ -542,6 +606,14 @@ public:
     /// </summary>
     void load(const std::vector<std::uint8_t> &data, const std::string &password);
 
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// Interprets byte vector data as an XLSX file encrypted with the
+    /// given password and sets the content of this workbook to match that file.
+    /// </summary>
+    void load(const std::vector<std::uint8_t> &data, std::u8string_view password);
+#endif
+
     /// <summary>
     /// Interprets file with the given filename as an XLSX file and sets
     /// the content of this workbook to match that file.
@@ -553,6 +625,21 @@ public:
     /// given password and sets the content of this workbook to match that file.
     /// </summary>
     void load(const std::string &filename, const std::string &password);
+
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// Interprets file with the given filename as an XLSX file and sets
+    /// the content of this workbook to match that file.
+    /// </summary>
+    void load(std::u8string_view filename);
+
+    /// <summary>
+    /// Interprets file with the given filename as an XLSX file encrypted with the
+    /// given password and sets the content of this workbook to match that file.
+    /// </summary>
+    void load(std::u8string_view filename, std::u8string_view password);
+#endif
+
 
 #ifdef _MSC_VER
     /// <summary>
@@ -580,6 +667,14 @@ public:
     /// </summary>
     void load(const xlnt::path &filename, const std::string &password);
 
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// Interprets file with the given filename as an XLSX file encrypted with the
+    /// given password and sets the content of this workbook to match that file.
+    /// </summary>
+    void load(const xlnt::path &filename, std::u8string_view password);
+#endif
+
     /// <summary>
     /// Interprets data in stream as an XLSX file and sets the content of this
     /// workbook to match that file.
@@ -591,6 +686,14 @@ public:
     /// and sets the content of this workbook to match that file.
     /// </summary>
     void load(std::istream &stream, const std::string &password);
+
+#ifdef __cpp_lib_char8_t
+    /// <summary>
+    /// Interprets data in stream as an XLSX file encrypted with the given password
+    /// and sets the content of this workbook to match that file.
+    /// </summary>
+    void load(std::istream &stream, std::u8string_view password);
+#endif
 
     // View
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.1...3.31)
 project(xlnt.samples)
 
-# Require C++11 compiler
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD ${XLNT_CXX_LANG})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD ${XLNT_C_LANG})
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CXX_EXTENSIONS OFF)
 
 if(NOT COMBINED_PROJECT)
   # Include xlnt library
@@ -35,7 +37,7 @@ foreach(SAMPLE_SOURCE IN ITEMS ${SAMPLE_SOURCES})
   target_include_directories(${SAMPLE_EXECUTABLE}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../tests)
   target_compile_definitions(${SAMPLE_EXECUTABLE}
-    PRIVATE XLNT_SAMPLE_DATA_DIR=${XLNT_SAMPLE_DATA_DIR})
+    PRIVATE XLNT_SAMPLE_DATA_DIR="${XLNT_SAMPLE_DATA_DIR}")
 
   if(MSVC AND NOT STATIC)
     # Copy xlnt DLL into samples directory

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -36,6 +36,9 @@ foreach(SAMPLE_SOURCE IN ITEMS ${SAMPLE_SOURCES})
   # Need to use some test helpers
   target_include_directories(${SAMPLE_EXECUTABLE}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../tests)
+  # Some helpers also need further internal includes
+  target_include_directories(${SAMPLE_EXECUTABLE}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../source)
   target_compile_definitions(${SAMPLE_EXECUTABLE}
     PRIVATE XLNT_SAMPLE_DATA_DIR="${XLNT_SAMPLE_DATA_DIR}")
 

--- a/source/detail/cryptography/xlsx_crypto_consumer.cpp
+++ b/source/detail/cryptography/xlsx_crypto_consumer.cpp
@@ -22,7 +22,6 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 
-#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -39,6 +38,7 @@
 #include <detail/serialization/vector_streambuf.hpp>
 #include <detail/serialization/xlsx_consumer.hpp>
 #include <detail/unicode.hpp>
+#include <detail/utils/string_helpers.hpp>
 
 namespace {
 
@@ -340,6 +340,13 @@ std::vector<std::uint8_t> decrypt_xlsx(const std::vector<std::uint8_t> &data, co
     return ::decrypt_xlsx(data, utf8_to_utf16(password));
 }
 
+#ifdef __cpp_lib_char8_t
+std::vector<std::uint8_t> decrypt_xlsx(const std::vector<std::uint8_t> &data, std::u8string_view password)
+{
+    return ::decrypt_xlsx(data, utf8_to_utf16(password));
+}
+#endif
+
 void xlsx_consumer::read(std::istream &source, const std::string &password)
 {
     std::vector<std::uint8_t> data((std::istreambuf_iterator<char>(source)), (std::istreambuf_iterator<char>()));
@@ -348,6 +355,13 @@ void xlsx_consumer::read(std::istream &source, const std::string &password)
     std::istream decrypted_stream(&decrypted_buffer);
     read(decrypted_stream);
 }
+
+#ifdef __cpp_lib_char8_t
+void xlsx_consumer::read(std::istream &source, std::u8string_view password)
+{
+    return read(source, detail::to_string_copy(password));
+}
+#endif
 
 } // namespace detail
 } // namespace xlnt

--- a/source/detail/cryptography/xlsx_crypto_consumer.cpp
+++ b/source/detail/cryptography/xlsx_crypto_consumer.cpp
@@ -340,7 +340,7 @@ std::vector<std::uint8_t> decrypt_xlsx(const std::vector<std::uint8_t> &data, co
     return ::decrypt_xlsx(data, utf8_to_utf16(password));
 }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 std::vector<std::uint8_t> decrypt_xlsx(const std::vector<std::uint8_t> &data, std::u8string_view password)
 {
     return ::decrypt_xlsx(data, utf8_to_utf16(password));
@@ -356,7 +356,7 @@ void xlsx_consumer::read(std::istream &source, const std::string &password)
     read(decrypted_stream);
 }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 void xlsx_consumer::read(std::istream &source, std::u8string_view password)
 {
     return read(source, detail::to_string_copy(password));

--- a/source/detail/cryptography/xlsx_crypto_consumer.cpp
+++ b/source/detail/cryptography/xlsx_crypto_consumer.cpp
@@ -347,7 +347,8 @@ std::vector<std::uint8_t> decrypt_xlsx(const std::vector<std::uint8_t> &data, st
 }
 #endif
 
-void xlsx_consumer::read(std::istream &source, const std::string &password)
+template <typename T>
+void xlsx_consumer::read_internal(std::istream &source, const T &password)
 {
     std::vector<std::uint8_t> data((std::istreambuf_iterator<char>(source)), (std::istreambuf_iterator<char>()));
     const auto decrypted = decrypt_xlsx(data, password);
@@ -356,10 +357,15 @@ void xlsx_consumer::read(std::istream &source, const std::string &password)
     read(decrypted_stream);
 }
 
+void xlsx_consumer::read(std::istream &source, const std::string &password)
+{
+    return read_internal(source, password);
+}
+
 #if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 void xlsx_consumer::read(std::istream &source, std::u8string_view password)
 {
-    return read(source, detail::to_string_copy(password));
+    return read_internal(source, password);
 }
 #endif
 

--- a/source/detail/cryptography/xlsx_crypto_consumer.hpp
+++ b/source/detail/cryptography/xlsx_crypto_consumer.hpp
@@ -26,29 +26,20 @@
 #include <string>
 #include <vector>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
-
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
-#endif
-
 #include <xlnt/xlnt_config.hpp>
 #include <detail/xlnt_config_impl.hpp>
+#include <xlnt/internal/features.hpp>
+
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
+#endif
 
 namespace xlnt {
 namespace detail {
 
 XLNT_API_INTERNAL std::vector<std::uint8_t> decrypt_xlsx(const std::vector<std::uint8_t> &bytes, const std::string &password);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 XLNT_API_INTERNAL std::vector<std::uint8_t> decrypt_xlsx(const std::vector<std::uint8_t> &bytes, std::u8string_view password);
 #endif
 

--- a/source/detail/cryptography/xlsx_crypto_consumer.hpp
+++ b/source/detail/cryptography/xlsx_crypto_consumer.hpp
@@ -26,12 +26,31 @@
 #include <string>
 #include <vector>
 
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
+
 #include <xlnt/xlnt_config.hpp>
+#include <detail/xlnt_config_impl.hpp>
 
 namespace xlnt {
 namespace detail {
 
-std::vector<std::uint8_t> XLNT_API_INTERNAL decrypt_xlsx(const std::vector<std::uint8_t> &bytes, const std::string &password);
+XLNT_API_INTERNAL std::vector<std::uint8_t> decrypt_xlsx(const std::vector<std::uint8_t> &bytes, const std::string &password);
+
+#ifdef __cpp_lib_char8_t
+XLNT_API_INTERNAL std::vector<std::uint8_t> decrypt_xlsx(const std::vector<std::uint8_t> &bytes, std::u8string_view password);
+#endif
 
 } // namespace detail
 } // namespace xlnt

--- a/source/detail/cryptography/xlsx_crypto_producer.cpp
+++ b/source/detail/cryptography/xlsx_crypto_producer.cpp
@@ -316,7 +316,8 @@ std::vector<std::uint8_t> encrypt_xlsx(
 }
 #endif
 
-void xlsx_producer::write(std::ostream &destination, const std::string &password)
+template <typename T>
+void xlsx_producer::write_internal(std::ostream &destination, const T &password)
 {
     std::vector<std::uint8_t> plaintext;
     vector_ostreambuf plaintext_buffer(plaintext);
@@ -330,10 +331,15 @@ void xlsx_producer::write(std::ostream &destination, const std::string &password
     destination << &encrypted_buffer;
 }
 
+void xlsx_producer::write(std::ostream &destination, const std::string &password)
+{
+    write_internal(destination, password);
+}
+
 #if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 void xlsx_producer::write(std::ostream &destination, std::u8string_view password)
 {
-    write(destination, detail::to_string_copy(password));
+    write_internal(destination, password);
 }
 #endif
 

--- a/source/detail/cryptography/xlsx_crypto_producer.cpp
+++ b/source/detail/cryptography/xlsx_crypto_producer.cpp
@@ -307,7 +307,7 @@ std::vector<std::uint8_t> encrypt_xlsx(
     return ::encrypt_xlsx(plaintext, utf8_to_utf16(password));
 }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 std::vector<std::uint8_t> encrypt_xlsx(
     const std::vector<std::uint8_t> &plaintext,
     std::u8string_view password)
@@ -330,7 +330,7 @@ void xlsx_producer::write(std::ostream &destination, const std::string &password
     destination << &encrypted_buffer;
 }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 void xlsx_producer::write(std::ostream &destination, std::u8string_view password)
 {
     write(destination, detail::to_string_copy(password));

--- a/source/detail/cryptography/xlsx_crypto_producer.cpp
+++ b/source/detail/cryptography/xlsx_crypto_producer.cpp
@@ -35,6 +35,7 @@
 #include <detail/serialization/xlsx_producer.hpp>
 #include <detail/serialization/zstream.hpp>
 #include <detail/unicode.hpp>
+#include <detail/utils/string_helpers.hpp>
 
 namespace {
 
@@ -306,6 +307,15 @@ std::vector<std::uint8_t> encrypt_xlsx(
     return ::encrypt_xlsx(plaintext, utf8_to_utf16(password));
 }
 
+#ifdef __cpp_lib_char8_t
+std::vector<std::uint8_t> encrypt_xlsx(
+    const std::vector<std::uint8_t> &plaintext,
+    std::u8string_view password)
+{
+    return ::encrypt_xlsx(plaintext, utf8_to_utf16(password));
+}
+#endif
+
 void xlsx_producer::write(std::ostream &destination, const std::string &password)
 {
     std::vector<std::uint8_t> plaintext;
@@ -319,6 +329,13 @@ void xlsx_producer::write(std::ostream &destination, const std::string &password
 
     destination << &encrypted_buffer;
 }
+
+#ifdef __cpp_lib_char8_t
+void xlsx_producer::write(std::ostream &destination, std::u8string_view password)
+{
+    write(destination, detail::to_string_copy(password));
+}
+#endif
 
 } // namespace detail
 } // namespace xlnt

--- a/source/detail/cryptography/xlsx_crypto_producer.hpp
+++ b/source/detail/cryptography/xlsx_crypto_producer.hpp
@@ -26,12 +26,31 @@
 #include <string>
 #include <vector>
 
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
+
 #include <xlnt/xlnt_config.hpp>
+#include <detail/xlnt_config_impl.hpp>
 
 namespace xlnt {
 namespace detail {
 
-std::vector<std::uint8_t> XLNT_API_INTERNAL encrypt_xlsx(const std::vector<std::uint8_t> &bytes, const std::string &password);
+XLNT_API_INTERNAL std::vector<std::uint8_t> encrypt_xlsx(const std::vector<std::uint8_t> &bytes, const std::string &password);
+
+#ifdef __cpp_lib_char8_t
+XLNT_API_INTERNAL std::vector<std::uint8_t> encrypt_xlsx(const std::vector<std::uint8_t> &bytes, std::u8string_view password);
+#endif
 
 } // namespace detail
 } // namespace xlnt

--- a/source/detail/cryptography/xlsx_crypto_producer.hpp
+++ b/source/detail/cryptography/xlsx_crypto_producer.hpp
@@ -26,29 +26,20 @@
 #include <string>
 #include <vector>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
-
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
-#endif
-
 #include <xlnt/xlnt_config.hpp>
 #include <detail/xlnt_config_impl.hpp>
+#include <xlnt/internal/features.hpp>
+
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
+#endif
 
 namespace xlnt {
 namespace detail {
 
 XLNT_API_INTERNAL std::vector<std::uint8_t> encrypt_xlsx(const std::vector<std::uint8_t> &bytes, const std::string &password);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 XLNT_API_INTERNAL std::vector<std::uint8_t> encrypt_xlsx(const std::vector<std::uint8_t> &bytes, std::u8string_view password);
 #endif
 

--- a/source/detail/implementations/workbook_impl.hpp
+++ b/source/detail/implementations/workbook_impl.hpp
@@ -92,7 +92,7 @@ struct workbook_impl
         return *this;
     }
 
-    bool operator==(const workbook_impl &other)
+    bool operator==(const workbook_impl &other) const
     {
         return active_sheet_index_ == other.active_sheet_index_
             && worksheets_ == other.worksheets_

--- a/source/detail/serialization/open_stream.cpp
+++ b/source/detail/serialization/open_stream.cpp
@@ -24,7 +24,10 @@
 
 #include <xlnt/utils/path.hpp>
 #include <detail/serialization/open_stream.hpp>
-#include "detail/utils/string_helpers.hpp"
+
+#if XLNT_HAS_INCLUDE(<filesystem>)
+  #include <filesystem>
+#endif
 
 namespace xlnt {
 namespace detail {
@@ -59,17 +62,21 @@ void open_stream(std::ofstream &stream, const std::wstring &path)
 }
 #endif
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 void open_stream(std::ifstream &stream, std::u8string_view path)
 {
 #ifdef _MSC_VER
     open_stream(stream, xlnt::path(path).wstring());
+#elif XLNT_HAS_FEATURE(FILESYSTEM)
+    stream.open(std::filesystem::path(path), std::ios::binary);
 #else
     // TODO: this cannot work if the user's locale is not UTF-8. In such cases we cannot ensure
     // that this always works - however, in such cases we can still attempt to do a conversion to
     // the locale encoding, which will still work if the string can be represented
     // with the user's locale encoding.
-    stream.open(to_const_char_ptr(path.data()), std::ios::binary);
+    // NOTE: this code will only run if C++17 is only partially implemented,
+    // but C++17 string_view and C++20 char8_t are implemented, while C++17 filesystem is not.
+    stream.open(to_char_ptr(path.data()), std::ios::binary);
 #endif
 }
 
@@ -77,12 +84,16 @@ void open_stream(std::ofstream &stream, std::u8string_view path)
 {
 #ifdef _MSC_VER
     open_stream(stream, xlnt::path(path).wstring());
+#elif XLNT_HAS_FEATURE(FILESYSTEM)
+    stream.open(std::filesystem::path(path), std::ios::binary);
 #else
     // TODO: this cannot work if the user's locale is not UTF-8. In such cases we cannot ensure
     // that this always works - however, in such cases we can still attempt to do a conversion to
     // the locale encoding, which will still work if the string can be represented
     // with the user's locale encoding.
-    stream.open(to_const_char_ptr(path.data()), std::ios::binary);
+    // NOTE: this code will only run if C++17 is only partially implemented,
+    // but C++17 string_view and C++20 char8_t are implemented, while C++17 filesystem is not.
+    stream.open(to_char_ptr(path.data()), std::ios::binary);
 #endif
 }
 #endif

--- a/source/detail/serialization/open_stream.cpp
+++ b/source/detail/serialization/open_stream.cpp
@@ -24,9 +24,28 @@
 
 #include <xlnt/utils/path.hpp>
 #include <detail/serialization/open_stream.hpp>
+#include "detail/utils/string_helpers.hpp"
 
 namespace xlnt {
 namespace detail {
+
+void open_stream(std::ifstream &stream, const std::string &path)
+{
+#ifdef _MSC_VER
+    open_stream(stream, xlnt::path(path).wstring());
+#else
+    stream.open(path, std::ios::binary);
+#endif
+}
+
+void open_stream(std::ofstream &stream, const std::string &path)
+{
+#ifdef _MSC_VER
+    open_stream(stream, xlnt::path(path).wstring());
+#else
+    stream.open(path, std::ios::binary);
+#endif
+}
 
 #ifdef _MSC_VER
 void open_stream(std::ifstream &stream, const std::wstring &path)
@@ -38,25 +57,33 @@ void open_stream(std::ofstream &stream, const std::wstring &path)
 {
     stream.open(path, std::ios::binary);
 }
+#endif
 
-void open_stream(std::ifstream &stream, const std::string &path)
+#ifdef __cpp_lib_char8_t
+void open_stream(std::ifstream &stream, std::u8string_view path)
 {
+#ifdef _MSC_VER
     open_stream(stream, xlnt::path(path).wstring());
-}
-
-void open_stream(std::ofstream &stream, const std::string &path)
-{
-    open_stream(stream, xlnt::path(path).wstring());
-}
 #else
-void open_stream(std::ifstream &stream, const std::string &path)
-{
-    stream.open(path, std::ios::binary);
+    // TODO: this cannot work if the user's locale is not UTF-8. In such cases we cannot ensure
+    // that this always works - however, in such cases we can still attempt to do a conversion to
+    // the locale encoding, which will still work if the string can be represented
+    // with the user's locale encoding.
+    stream.open(to_const_char_ptr(path.data()), std::ios::binary);
+#endif
 }
 
-void open_stream(std::ofstream &stream, const std::string &path)
+void open_stream(std::ofstream &stream, std::u8string_view path)
 {
-    stream.open(path, std::ios::binary);
+#ifdef _MSC_VER
+    open_stream(stream, xlnt::path(path).wstring());
+#else
+    // TODO: this cannot work if the user's locale is not UTF-8. In such cases we cannot ensure
+    // that this always works - however, in such cases we can still attempt to do a conversion to
+    // the locale encoding, which will still work if the string can be represented
+    // with the user's locale encoding.
+    stream.open(to_const_char_ptr(path.data()), std::ios::binary);
+#endif
 }
 #endif
 

--- a/source/detail/serialization/open_stream.hpp
+++ b/source/detail/serialization/open_stream.hpp
@@ -25,24 +25,39 @@
 #pragma once
 
 #include <fstream>
-#include <iostream>
 #include <string>
+
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
 
 namespace xlnt {
 namespace detail {
+
+void open_stream(std::ifstream &stream, const std::string &path);
+
+void open_stream(std::ofstream &stream, const std::string &path);
+
+#ifdef __cpp_lib_char8_t
+void open_stream(std::ifstream &stream, std::u8string_view path);
+
+void open_stream(std::ofstream &stream, std::u8string_view path);
+#endif
 
 #ifdef _MSC_VER
 void open_stream(std::ifstream &stream, const std::wstring &path);
 
 void open_stream(std::ofstream &stream, const std::wstring &path);
-
-void open_stream(std::ifstream &stream, const std::string &path);
-
-void open_stream(std::ofstream &stream, const std::string &path);
-#else
-void open_stream(std::ifstream &stream, const std::string &path);
-
-void open_stream(std::ofstream &stream, const std::string &path);
 #endif
 
 } // namespace detail

--- a/source/detail/serialization/open_stream.hpp
+++ b/source/detail/serialization/open_stream.hpp
@@ -27,18 +27,10 @@
 #include <fstream>
 #include <string>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
+#include <xlnt/internal/features.hpp>
 
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
 #endif
 
 namespace xlnt {
@@ -48,7 +40,7 @@ void open_stream(std::ifstream &stream, const std::string &path);
 
 void open_stream(std::ofstream &stream, const std::string &path);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 void open_stream(std::ifstream &stream, std::u8string_view path);
 
 void open_stream(std::ofstream &stream, std::u8string_view path);

--- a/source/detail/serialization/vector_streambuf.hpp
+++ b/source/detail/serialization/vector_streambuf.hpp
@@ -89,8 +89,6 @@ private:
     std::size_t position_;
 };
 
-//TODO: detail headers shouldn't be exporting such functions
-
 /// <summary>
 /// Helper function to read all data from in_stream and store them in a vector.
 /// </summary>

--- a/source/detail/serialization/xlsx_consumer.hpp
+++ b/source/detail/serialization/xlsx_consumer.hpp
@@ -32,23 +32,14 @@
 #include <unordered_map>
 #include <vector>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
-
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
-#endif
-
 #include <detail/external/include_libstudxml.hpp>
 #include <detail/serialization/zstream.hpp>
 #include <detail/serialization/serialisation_helpers.hpp>
+#include <xlnt/internal/features.hpp>
+
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
+#endif
 
 namespace xlnt {
 
@@ -87,7 +78,7 @@ public:
 
 	void read(std::istream &source, const std::string &password);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 	void read(std::istream &source, std::u8string_view password);
 #endif
 

--- a/source/detail/serialization/xlsx_consumer.hpp
+++ b/source/detail/serialization/xlsx_consumer.hpp
@@ -26,13 +26,25 @@
 #pragma once
 
 #include <detail/xlnt_config_impl.hpp>
-#include <cstdint>
-#include <functional>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
 
 #include <detail/external/include_libstudxml.hpp>
 #include <detail/serialization/zstream.hpp>
@@ -75,8 +87,12 @@ public:
 
 	void read(std::istream &source, const std::string &password);
 
-        // For unit testing purpose only
-        void read_stylesheet (const std::string& xml);
+#ifdef __cpp_lib_char8_t
+	void read(std::istream &source, std::u8string_view password);
+#endif
+
+    // For unit testing purpose only
+    void read_stylesheet (const std::string& xml);
 
 private:
     friend class xlnt::streaming_workbook_reader;

--- a/source/detail/serialization/xlsx_consumer.hpp
+++ b/source/detail/serialization/xlsx_consumer.hpp
@@ -90,6 +90,9 @@ private:
 
     void open(std::istream &source);
 
+    template <typename T>
+    void read_internal(std::istream &source, const T &password);
+
     bool has_cell();
 
     /// <summary>

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -87,6 +87,9 @@ private:
 
     void open(std::ostream &destination);
 
+    template <typename T>
+    void write_internal(std::ostream &destination, const T &password);
+
     cell add_cell(const cell_reference &ref);
 
     worksheet add_worksheet(const std::string &title);

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -24,11 +24,24 @@
 
 #pragma once
 
-#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <type_traits>
 #include <vector>
+
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
 
 #include <detail/constants.hpp>
 #include <detail/external/include_libstudxml.hpp>
@@ -73,6 +86,10 @@ public:
 	void write(std::ostream &destination);
 
     void write(std::ostream &destination, const std::string &password);
+
+#ifdef __cpp_lib_char8_t
+    void write(std::ostream &destination, std::u8string_view password);
+#endif
 
 private:
     friend class xlnt::streaming_workbook_writer;

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -29,23 +29,14 @@
 #include <type_traits>
 #include <vector>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
-
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
-#endif
-
 #include <detail/constants.hpp>
 #include <detail/external/include_libstudxml.hpp>
 #include <detail/serialization/serialisation_helpers.hpp>
+#include <xlnt/internal/features.hpp>
+
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
+#endif
 
 namespace xml {
 class serializer;
@@ -87,7 +78,7 @@ public:
 
     void write(std::ostream &destination, const std::string &password);
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     void write(std::ostream &destination, std::u8string_view password);
 #endif
 

--- a/source/detail/serialization/zstream.hpp
+++ b/source/detail/serialization/zstream.hpp
@@ -43,8 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/utils/path.hpp>
 
-//TODO: don't export these classes (some tests are using them for now)
-
 namespace xlnt {
 namespace detail {
 

--- a/source/detail/unicode.cpp
+++ b/source/detail/unicode.cpp
@@ -95,7 +95,7 @@ size_t string_length(const std::string &utf8_string)
     return static_cast<std::size_t>(utf8::distance(utf8_string.begin(), end_it));
 }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 std::u16string utf8_to_utf16(std::u8string_view utf8_string)
 {
     std::u16string result;
@@ -110,14 +110,14 @@ std::u32string utf8_to_utf32(std::u8string_view utf8_string)
     return result;
 }
 
-std::u8string utf16_to_utf8(std::u16string_view utf16_string)
+std::u8string utf16_to_utf8_u8(std::u16string_view utf16_string)
 {
     std::u8string result;
     utf8::utf16to8(utf16_string.begin(), utf16_string.end(), std::back_inserter(result));
     return result;
 }
 
-std::u8string utf32_to_utf8(std::u32string_view utf32_string)
+std::u8string utf32_to_utf8_u8(std::u32string_view utf32_string)
 {
     std::u8string result;
     utf8::utf32to8(utf32_string.begin(), utf32_string.end(), std::back_inserter(result));

--- a/source/detail/unicode.cpp
+++ b/source/detail/unicode.cpp
@@ -40,7 +40,13 @@ std::u16string utf8_to_utf16(const std::string &utf8_string)
 {
     std::u16string result;
     utf8::utf8to16(utf8_string.begin(), utf8_string.end(), std::back_inserter(result));
+    return result;
+}
 
+std::u32string utf8_to_utf32(const std::string &utf8_string)
+{
+    std::u32string result;
+    utf8::utf8to32(utf8_string.begin(), utf8_string.end(), std::back_inserter(result));
     return result;
 }
 
@@ -48,7 +54,13 @@ std::string utf16_to_utf8(const std::u16string &utf16_string)
 {
     std::string result;
     utf8::utf16to8(utf16_string.begin(), utf16_string.end(), std::back_inserter(result));
+    return result;
+}
 
+std::string utf32_to_utf8(const std::u32string &utf32_string)
+{
+    std::string result;
+    utf8::utf32to8(utf32_string.begin(), utf32_string.end(), std::back_inserter(result));
     return result;
 }
 
@@ -82,6 +94,36 @@ size_t string_length(const std::string &utf8_string)
 
     return static_cast<std::size_t>(utf8::distance(utf8_string.begin(), end_it));
 }
+
+#ifdef __cpp_lib_char8_t
+std::u16string utf8_to_utf16(std::u8string_view utf8_string)
+{
+    std::u16string result;
+    utf8::utf8to16(utf8_string.begin(), utf8_string.end(), std::back_inserter(result));
+    return result;
+}
+
+std::u32string utf8_to_utf32(std::u8string_view utf8_string)
+{
+    std::u32string result;
+    utf8::utf8to32(utf8_string.begin(), utf8_string.end(), std::back_inserter(result));
+    return result;
+}
+
+std::u8string utf16_to_utf8(std::u16string_view utf16_string)
+{
+    std::u8string result;
+    utf8::utf16to8(utf16_string.begin(), utf16_string.end(), std::back_inserter(result));
+    return result;
+}
+
+std::u8string utf32_to_utf8(std::u32string_view utf32_string)
+{
+    std::u8string result;
+    utf8::utf32to8(utf32_string.begin(), utf32_string.end(), std::back_inserter(result));
+    return result;
+}
+#endif
 
 } // namespace detail
 } // namespace xlnt

--- a/source/detail/unicode.hpp
+++ b/source/detail/unicode.hpp
@@ -26,35 +26,28 @@
 
 #include <string>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
+#include <xlnt/internal/features.hpp>
+#include <detail/xlnt_config_impl.hpp>
 
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
 #endif
 
 namespace xlnt {
 namespace detail {
 
-std::u16string utf8_to_utf16(const std::string &utf8_string);
-std::u32string utf8_to_utf32(const std::string &utf8_string);
-std::string utf16_to_utf8(const std::u16string &utf16_string);
-std::string utf32_to_utf8(const std::u32string &utf32_string);
-std::string latin1_to_utf8(const std::string &latin1);
-size_t string_length(const std::string &utf8_string);
+XLNT_API_INTERNAL std::u16string utf8_to_utf16(const std::string &utf8_string);
+XLNT_API_INTERNAL std::u32string utf8_to_utf32(const std::string &utf8_string);
+XLNT_API_INTERNAL std::string utf16_to_utf8(const std::u16string &utf16_string);
+XLNT_API_INTERNAL std::string utf32_to_utf8(const std::u32string &utf32_string);
+XLNT_API_INTERNAL std::string latin1_to_utf8(const std::string &latin1);
+XLNT_API_INTERNAL size_t string_length(const std::string &utf8_string);
 
-#ifdef __cpp_lib_char8_t
-std::u16string utf8_to_utf16(std::u8string_view utf8_string);
-std::u32string utf8_to_utf32(std::u8string_view utf8_string);
-std::u8string utf16_to_utf8(std::u16string_view utf16_string);
-std::u8string utf32_to_utf8(std::u32string_view utf32_string);
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+XLNT_API_INTERNAL std::u16string utf8_to_utf16(std::u8string_view utf8_string);
+XLNT_API_INTERNAL std::u32string utf8_to_utf32(std::u8string_view utf8_string);
+XLNT_API_INTERNAL std::u8string utf16_to_utf8_u8(std::u16string_view utf16_string);
+XLNT_API_INTERNAL std::u8string utf32_to_utf8_u8(std::u32string_view utf32_string);
 #endif
 
 } // namespace detail

--- a/source/detail/unicode.hpp
+++ b/source/detail/unicode.hpp
@@ -26,13 +26,36 @@
 
 #include <string>
 
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
+
 namespace xlnt {
 namespace detail {
 
 std::u16string utf8_to_utf16(const std::string &utf8_string);
+std::u32string utf8_to_utf32(const std::string &utf8_string);
 std::string utf16_to_utf8(const std::u16string &utf16_string);
+std::string utf32_to_utf8(const std::u32string &utf32_string);
 std::string latin1_to_utf8(const std::string &latin1);
 size_t string_length(const std::string &utf8_string);
+
+#ifdef __cpp_lib_char8_t
+std::u16string utf8_to_utf16(std::u8string_view utf8_string);
+std::u32string utf8_to_utf32(std::u8string_view utf8_string);
+std::u8string utf16_to_utf8(std::u16string_view utf16_string);
+std::u8string utf32_to_utf8(std::u32string_view utf32_string);
+#endif
 
 } // namespace detail
 } // namespace xlnt

--- a/source/detail/utils/string_helpers.hpp
+++ b/source/detail/utils/string_helpers.hpp
@@ -26,47 +26,43 @@
 #include <string>
 #include <vector>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
-
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
-#endif
-
 #include <detail/xlnt_config_impl.hpp>
+#include <xlnt/internal/features.hpp>
+
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
+#endif
 
 namespace xlnt {
 namespace detail {
 
+// Prepends the string literal prefix to the provided string literal.
+// Useful when defining a string literal once, then using it with multiple string types.
 #define LSTRING_LITERAL2(a) L##a
 #define U8STRING_LITERAL2(a) u8##a
-#define U16STRING_LITERAL2(a) u16##a
-#define U32STRING_LITERAL2(a) u32##a
+#define U16STRING_LITERAL2(a) u##a
+#define U32STRING_LITERAL2(a) U##a
 #define LSTRING_LITERAL(a) LSTRING_LITERAL2(a)
 #define U8STRING_LITERAL(a) U8STRING_LITERAL2(a)
 #define U16STRING_LITERAL(a) U16STRING_LITERAL2(a)
 #define U32STRING_LITERAL(a) U32STRING_LITERAL2(a)
 
+// Casts a UTF-8 string literal to a narrow string literal without changing its encoding.
 #ifdef __cpp_char8_t
 // For C++20 and newer, interpret as UTF-8 and then cast to string literal
-#define U8_CAST_CONST_LITERAL(a) xlnt::detail::to_const_char_ptr(a)
 #define U8_CAST_LITERAL(a) xlnt::detail::to_char_ptr(a)
 #else
 // For C++11, C++14 and C++17, simply interpret as UTF-8, which works with classic string literals.
-#define U8_CAST_CONST_LITERAL(a) a
 #define U8_CAST_LITERAL(a) a
 #endif
 
+
+// The following weird cast ensures that the string is UTF-8 encoded at all costs!
+#define LITERAL_AS_U8(a) U8_CAST_LITERAL(U8STRING_LITERAL(a))
+
 #ifdef __cpp_char8_t
 /// Casts const char8_t arrays from C++20 to const char arrays.
-inline const char * to_const_char_ptr(const char8_t *utf8)
+inline const char * to_char_ptr(const char8_t *utf8)
 {
     return reinterpret_cast<const char *>(utf8);
 }
@@ -78,11 +74,11 @@ inline char * to_char_ptr(char8_t *utf8)
 }
 #endif
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 /// Casts std::u8string_view from C++20 to std::string_view.
 inline std::string_view to_string_view(std::u8string_view utf8)
 {
-    return std::string_view{to_const_char_ptr(utf8.data()), utf8.length()};
+    return std::string_view{to_char_ptr(utf8.data()), utf8.length()};
 }
 
 /// Copies std::u8string(_view) from C++20 to std::string.

--- a/source/detail/utils/string_helpers.hpp
+++ b/source/detail/utils/string_helpers.hpp
@@ -26,10 +26,71 @@
 #include <string>
 #include <vector>
 
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
+
 #include <detail/xlnt_config_impl.hpp>
 
 namespace xlnt {
 namespace detail {
+
+#define LSTRING_LITERAL2(a) L##a
+#define U8STRING_LITERAL2(a) u8##a
+#define U16STRING_LITERAL2(a) u16##a
+#define U32STRING_LITERAL2(a) u32##a
+#define LSTRING_LITERAL(a) LSTRING_LITERAL2(a)
+#define U8STRING_LITERAL(a) U8STRING_LITERAL2(a)
+#define U16STRING_LITERAL(a) U16STRING_LITERAL2(a)
+#define U32STRING_LITERAL(a) U32STRING_LITERAL2(a)
+
+#ifdef __cpp_char8_t
+// For C++20 and newer, interpret as UTF-8 and then cast to string literal
+#define U8_CAST_CONST_LITERAL(a) xlnt::detail::to_const_char_ptr(a)
+#define U8_CAST_LITERAL(a) xlnt::detail::to_char_ptr(a)
+#else
+// For C++11, C++14 and C++17, simply interpret as UTF-8, which works with classic string literals.
+#define U8_CAST_CONST_LITERAL(a) a
+#define U8_CAST_LITERAL(a) a
+#endif
+
+#ifdef __cpp_char8_t
+/// Casts const char8_t arrays from C++20 to const char arrays.
+inline const char * to_const_char_ptr(const char8_t *utf8)
+{
+    return reinterpret_cast<const char *>(utf8);
+}
+
+/// Casts char8_t arrays from C++20 to char arrays.
+inline char * to_char_ptr(char8_t *utf8)
+{
+    return reinterpret_cast<char *>(utf8);
+}
+#endif
+
+#ifdef __cpp_lib_char8_t
+/// Casts std::u8string_view from C++20 to std::string_view.
+inline std::string_view to_string_view(std::u8string_view utf8)
+{
+    return std::string_view{to_const_char_ptr(utf8.data()), utf8.length()};
+}
+
+/// Copies std::u8string(_view) from C++20 to std::string.
+inline std::string to_string_copy(std::u8string_view utf8)
+{
+    return std::string{utf8.begin(), utf8.end()};
+}
+#endif
 
 /// <summary>
 /// Return a vector containing string split at each delim.

--- a/source/detail/utils/string_helpers.hpp
+++ b/source/detail/utils/string_helpers.hpp
@@ -50,15 +50,15 @@ namespace detail {
 // Casts a UTF-8 string literal to a narrow string literal without changing its encoding.
 #ifdef __cpp_char8_t
 // For C++20 and newer, interpret as UTF-8 and then cast to string literal
-#define U8_CAST_LITERAL(a) xlnt::detail::to_char_ptr(a)
+#define U8_TO_CHAR_PTR(a) xlnt::detail::to_char_ptr(a)
 #else
 // For C++11, C++14 and C++17, simply interpret as UTF-8, which works with classic string literals.
-#define U8_CAST_LITERAL(a) a
+#define U8_TO_CHAR_PTR(a) a
 #endif
 
 
 // The following weird cast ensures that the string is UTF-8 encoded at all costs!
-#define LITERAL_AS_U8(a) U8_CAST_LITERAL(U8STRING_LITERAL(a))
+#define ENSURE_UTF8_LITERAL(a) U8_TO_CHAR_PTR(U8STRING_LITERAL(a))
 
 #ifdef __cpp_char8_t
 /// Casts const char8_t arrays from C++20 to const char arrays.

--- a/source/utils/path.cpp
+++ b/source/utils/path.cpp
@@ -160,7 +160,7 @@ path::path(const std::string &path_string, char sep)
     }
 }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 path::path(std::u8string_view path_string)
     : path(detail::to_string_copy(path_string))
 {
@@ -336,7 +336,7 @@ path path::append(const std::string &to_append) const
     return copy;
 }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
 path path::append(std::u8string_view to_append) const
 {
     return append(detail::to_string_copy(to_append));

--- a/source/utils/path.cpp
+++ b/source/utils/path.cpp
@@ -117,13 +117,13 @@ std::vector<std::string> split_path(const std::string &path, char delim)
 #ifdef _MSC_VER
 bool file_exists(const std::wstring &path)
 {
-    struct stat info;
+    struct _stat info;
     return _wstat(path.c_str(), &info) == 0 && (info.st_mode & S_IFREG);
 }
 
 bool directory_exists(const std::wstring &path)
 {
-    struct stat info;
+    struct _stat info;
     return _wstat(path.c_str(), &info) == 0 && (info.st_mode & S_IFDIR);
 }
 #else

--- a/source/utils/path.cpp
+++ b/source/utils/path.cpp
@@ -114,17 +114,31 @@ std::vector<std::string> split_path(const std::string &path, char delim)
     return split;
 }
 
+#ifdef _MSC_VER
+bool file_exists(const std::wstring &path)
+{
+    struct stat info;
+    return _wstat(path.c_str(), &info) == 0 && (info.st_mode & S_IFREG);
+}
+
+bool directory_exists(const std::wstring &path)
+{
+    struct stat info;
+    return _wstat(path.c_str(), &info) == 0 && (info.st_mode & S_IFDIR);
+}
+#else
 bool file_exists(const std::string &path)
 {
     struct stat info;
     return stat(path.c_str(), &info) == 0 && (info.st_mode & S_IFREG);
 }
 
-bool directory_exists(const std::string path)
+bool directory_exists(const std::string &path)
 {
     struct stat info;
     return stat(path.c_str(), &info) == 0 && (info.st_mode & S_IFDIR);
 }
+#endif
 
 } // namespace
 
@@ -301,19 +315,31 @@ bool path::exists() const
 
 bool path::is_directory() const
 {
+#ifdef _MSC_VER
+    return directory_exists(wstring());
+#else
     return directory_exists(string());
+#endif
 }
 
 bool path::is_file() const
 {
+#ifdef _MSC_VER
+    return file_exists(wstring());
+#else
     return file_exists(string());
+#endif
 }
 
 // filesystem
 
 std::string path::read_contents() const
 {
+#ifdef _MSC_VER
+    std::ifstream f(wstring());
+#else
     std::ifstream f(string());
+#endif
     std::ostringstream ss;
     ss << f.rdbuf();
 

--- a/source/utils/path.cpp
+++ b/source/utils/path.cpp
@@ -39,6 +39,7 @@
 
 #include <xlnt/utils/path.hpp>
 #include <detail/external/include_windows.hpp>
+#include <detail/utils/string_helpers.hpp>
 
 namespace {
 
@@ -158,6 +159,21 @@ path::path(const std::string &path_string, char sep)
         }
     }
 }
+
+#ifdef __cpp_lib_char8_t
+path::path(std::u8string_view path_string)
+    : path(detail::to_string_copy(path_string))
+{
+
+}
+
+path::path(std::u8string_view path_string, char sep)
+    : path(detail::to_string_copy(path_string), sep)
+{
+
+}
+#endif
+
 
 // general attributes
 
@@ -319,6 +335,13 @@ path path::append(const std::string &to_append) const
 
     return copy;
 }
+
+#ifdef __cpp_lib_char8_t
+path path::append(std::u8string_view to_append) const
+{
+    return append(detail::to_string_copy(to_append));
+}
+#endif
 
 path path::append(const path &to_append) const
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,9 +64,10 @@ target_include_directories(xlnt.test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../third-party/fast_float/include)
 
 set(XLNT_TEST_DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
-target_compile_definitions(xlnt.test PRIVATE XLNT_TEST_DATA_DIR=${XLNT_TEST_DATA_DIR})
+target_compile_definitions(xlnt.test PRIVATE XLNT_TEST_DATA_DIR="${XLNT_TEST_DATA_DIR}")
 # requires cmake 3.8+
 #target_compile_features(xlnt.test PRIVATE cxx_std_${XLNT_CXX_LANG})
+#target_compile_features(xlnt.test PRIVATE c_std_${XLNT_C_LANG})
 
 if (XLNT_USE_LOCALE_COMMA_DECIMAL_SEPARATOR)
   target_compile_definitions(xlnt.test PRIVATE XLNT_USE_LOCALE_COMMA_DECIMAL_SEPARATOR=1)

--- a/tests/helpers/path_helper.hpp
+++ b/tests/helpers/path_helper.hpp
@@ -3,23 +3,14 @@
 #include <fstream>
 #include <string>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
-
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
-#endif
-
 #include <xlnt/utils/exceptions.hpp>
 #include <xlnt/utils/path.hpp>
 #include <detail/utils/string_helpers.hpp>
+#include <xlnt/internal/features.hpp>
+
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
+#endif
 
 #ifndef XLNT_TEST_DATA_DIR
 #define XLNT_TEST_DATA_DIR ""
@@ -36,84 +27,57 @@
 class path_helper
 {
 public:
-    static xlnt::path test_data_directory(const std::string &append = "")
+    static xlnt::path test_data_directory()
     {
-        // Note: the following weird cast ensures that the string is UTF-8 encoded at all costs!
-        static const std::string data_dir = U8_CAST_CONST_LITERAL(U8STRING_LITERAL(XLNT_TEST_DATA_DIR));
+        static const std::string data_dir = LITERAL_AS_U8(XLNT_TEST_DATA_DIR);
         return xlnt::path(data_dir);
     }
-
-#ifdef __cpp_lib_char8_t
-    static xlnt::path test_data_directory_u8(std::u8string_view append = u8"")
-    {
-        static constexpr std::u8string_view data_dir = U8STRING_LITERAL(XLNT_TEST_DATA_DIR);
-        return xlnt::path(data_dir);
-    }
-#endif
 
     static xlnt::path test_file(const std::string &filename)
     {
         return test_data_directory().append(xlnt::path(filename));
     }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     static xlnt::path test_file(std::u8string_view filename)
     {
-        return test_data_directory_u8().append(xlnt::path(filename));
+        return test_data_directory().append(xlnt::path(filename));
     }
 #endif
 
-    static xlnt::path benchmark_data_directory(const std::string &append = "")
+    static xlnt::path benchmark_data_directory()
     {
-        // Note: the following weird cast ensures that the string is UTF-8 encoded at all costs!
-        static const std::string data_dir = U8_CAST_CONST_LITERAL(U8STRING_LITERAL(XLNT_BENCHMARK_DATA_DIR));
+        static const std::string data_dir = LITERAL_AS_U8(XLNT_BENCHMARK_DATA_DIR);
         return xlnt::path(data_dir);
     }
-
-#ifdef __cpp_lib_char8_t
-    static xlnt::path benchmark_data_directory_u8(std::u8string_view append = u8"")
-    {
-        static constexpr std::u8string_view data_dir = U8STRING_LITERAL(XLNT_BENCHMARK_DATA_DIR);
-        return xlnt::path(data_dir);
-    }
-#endif
 
     static xlnt::path benchmark_file(const std::string &filename)
     {
         return benchmark_data_directory().append(xlnt::path(filename));
     }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     static xlnt::path benchmark_file(std::u8string_view filename)
     {
-        return benchmark_data_directory_u8().append(xlnt::path(filename));
+        return benchmark_data_directory().append(xlnt::path(filename));
     }
 #endif
 
-    static xlnt::path sample_data_directory(const std::string &append = "")
+    static xlnt::path sample_data_directory()
     {
-        // Note: the following weird cast ensures that the string is UTF-8 encoded at all costs!
-        static const std::string data_dir = U8_CAST_CONST_LITERAL(U8STRING_LITERAL(XLNT_SAMPLE_DATA_DIR));
+        static const std::string data_dir = LITERAL_AS_U8(XLNT_SAMPLE_DATA_DIR);
         return xlnt::path(data_dir);
     }
-
-#ifdef __cpp_lib_char8_t
-    static xlnt::path sample_data_directory_u8(std::u8string_view append = u8"")
-    {
-        static constexpr std::u8string_view data_dir = U8STRING_LITERAL(XLNT_SAMPLE_DATA_DIR);
-        return xlnt::path(data_dir);
-    }
-#endif
 
     static xlnt::path sample_file(const std::string &filename)
     {
         return sample_data_directory().append(xlnt::path(filename));
     }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     static xlnt::path sample_file(std::u8string_view filename)
     {
-        return sample_data_directory_u8().append(xlnt::path(filename));
+        return sample_data_directory().append(xlnt::path(filename));
     }
 #endif
 

--- a/tests/helpers/path_helper.hpp
+++ b/tests/helpers/path_helper.hpp
@@ -1,19 +1,29 @@
 #pragma once
 
-#include <array>
 #include <fstream>
 #include <string>
-#include <sstream>
+
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
 
 #include <xlnt/utils/exceptions.hpp>
 #include <xlnt/utils/path.hpp>
+#include <detail/utils/string_helpers.hpp>
 
-#define STRING_LITERAL2(a) #a
-#define LSTRING_LITERAL2(a) L#a
-#define U8STRING_LITERAL2(a) u8#a
-#define STRING_LITERAL(a) STRING_LITERAL2(a)
-#define LSTRING_LITERAL(a) STRING_LITERAL2(a)
-#define U8STRING_LITERAL(a) STRING_LITERAL2(a)
+#ifndef XLNT_TEST_DATA_DIR
+#define XLNT_TEST_DATA_DIR ""
+#endif
 
 #ifndef XLNT_BENCHMARK_DATA_DIR
 #define XLNT_BENCHMARK_DATA_DIR ""
@@ -28,36 +38,84 @@ class path_helper
 public:
     static xlnt::path test_data_directory(const std::string &append = "")
     {
-        static const std::string data_dir = STRING_LITERAL(XLNT_TEST_DATA_DIR);
+        // Note: the following weird cast ensures that the string is UTF-8 encoded at all costs!
+        static const std::string data_dir = U8_CAST_CONST_LITERAL(U8STRING_LITERAL(XLNT_TEST_DATA_DIR));
         return xlnt::path(data_dir);
     }
+
+#ifdef __cpp_lib_char8_t
+    static xlnt::path test_data_directory_u8(std::u8string_view append = u8"")
+    {
+        static constexpr std::u8string_view data_dir = U8STRING_LITERAL(XLNT_TEST_DATA_DIR);
+        return xlnt::path(data_dir);
+    }
+#endif
 
     static xlnt::path test_file(const std::string &filename)
     {
         return test_data_directory().append(xlnt::path(filename));
     }
 
+#ifdef __cpp_lib_char8_t
+    static xlnt::path test_file(std::u8string_view filename)
+    {
+        return test_data_directory_u8().append(xlnt::path(filename));
+    }
+#endif
+
     static xlnt::path benchmark_data_directory(const std::string &append = "")
     {
-        static const std::string data_dir = STRING_LITERAL(XLNT_BENCHMARK_DATA_DIR);
+        // Note: the following weird cast ensures that the string is UTF-8 encoded at all costs!
+        static const std::string data_dir = U8_CAST_CONST_LITERAL(U8STRING_LITERAL(XLNT_BENCHMARK_DATA_DIR));
         return xlnt::path(data_dir);
     }
+
+#ifdef __cpp_lib_char8_t
+    static xlnt::path benchmark_data_directory_u8(std::u8string_view append = u8"")
+    {
+        static constexpr std::u8string_view data_dir = U8STRING_LITERAL(XLNT_BENCHMARK_DATA_DIR);
+        return xlnt::path(data_dir);
+    }
+#endif
 
     static xlnt::path benchmark_file(const std::string &filename)
     {
         return benchmark_data_directory().append(xlnt::path(filename));
     }
 
+#ifdef __cpp_lib_char8_t
+    static xlnt::path benchmark_file(std::u8string_view filename)
+    {
+        return benchmark_data_directory_u8().append(xlnt::path(filename));
+    }
+#endif
+
     static xlnt::path sample_data_directory(const std::string &append = "")
     {
-        static const std::string data_dir = STRING_LITERAL(XLNT_SAMPLE_DATA_DIR);
+        // Note: the following weird cast ensures that the string is UTF-8 encoded at all costs!
+        static const std::string data_dir = U8_CAST_CONST_LITERAL(U8STRING_LITERAL(XLNT_SAMPLE_DATA_DIR));
         return xlnt::path(data_dir);
     }
+
+#ifdef __cpp_lib_char8_t
+    static xlnt::path sample_data_directory_u8(std::u8string_view append = u8"")
+    {
+        static constexpr std::u8string_view data_dir = U8STRING_LITERAL(XLNT_SAMPLE_DATA_DIR);
+        return xlnt::path(data_dir);
+    }
+#endif
 
     static xlnt::path sample_file(const std::string &filename)
     {
         return sample_data_directory().append(xlnt::path(filename));
     }
+
+#ifdef __cpp_lib_char8_t
+    static xlnt::path sample_file(std::u8string_view filename)
+    {
+        return sample_data_directory_u8().append(xlnt::path(filename));
+    }
+#endif
 
     static void copy_file(const xlnt::path &source, const xlnt::path &destination, bool overwrite)
     {

--- a/tests/helpers/path_helper.hpp
+++ b/tests/helpers/path_helper.hpp
@@ -29,7 +29,7 @@ class path_helper
 public:
     static xlnt::path test_data_directory()
     {
-        static const std::string data_dir = LITERAL_AS_U8(XLNT_TEST_DATA_DIR);
+        static const std::string data_dir = ENSURE_UTF8_LITERAL(XLNT_TEST_DATA_DIR);
         return xlnt::path(data_dir);
     }
 
@@ -47,7 +47,7 @@ public:
 
     static xlnt::path benchmark_data_directory()
     {
-        static const std::string data_dir = LITERAL_AS_U8(XLNT_BENCHMARK_DATA_DIR);
+        static const std::string data_dir = ENSURE_UTF8_LITERAL(XLNT_BENCHMARK_DATA_DIR);
         return xlnt::path(data_dir);
     }
 
@@ -65,7 +65,7 @@ public:
 
     static xlnt::path sample_data_directory()
     {
-        static const std::string data_dir = LITERAL_AS_U8(XLNT_SAMPLE_DATA_DIR);
+        static const std::string data_dir = ENSURE_UTF8_LITERAL(XLNT_SAMPLE_DATA_DIR);
         return xlnt::path(data_dir);
     }
 

--- a/tests/internal/numeric_util_test_suite.cpp
+++ b/tests/internal/numeric_util_test_suite.cpp
@@ -23,6 +23,7 @@
 // @author: see AUTHORS file
 
 #include <detail/serialization/serialisation_helpers.hpp>
+#include <xlnt/utils/numeric.hpp>
 #include <internal/locale_helpers.hpp>
 #include <helpers/test_suite.hpp>
 #include <cstring>

--- a/tests/internal/serialization_test_suite.cpp
+++ b/tests/internal/serialization_test_suite.cpp
@@ -360,7 +360,7 @@ public:
         // L"/9_unicode_\u039B_\U0001F607.xlsx" gives the correct output
         const auto path = LSTRING_LITERAL(XLNT_TEST_DATA_DIR) L"/9_unicode_\u039B_\U0001F607.xlsx"; // L"/9_unicode_Λ_😇.xlsx"
         wb.load(path);
-        xlnt_assert_equals(wb.active_sheet().cell("A1").value<std::string>(), U8_CAST_LITERAL(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
+        xlnt_assert_equals(wb.active_sheet().cell("A1").value<std::string>(), U8_TO_CHAR_PTR(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
 #endif
 
 #ifndef __MINGW32__
@@ -369,7 +369,7 @@ public:
         // u8"/9_unicode_\u039B_\U0001F607.xlsx" gives the correct output
         const auto path2 = U8STRING_LITERAL(XLNT_TEST_DATA_DIR) u8"/9_unicode_\u039B_\U0001F607.xlsx"; // u8"/9_unicode_Λ_😇.xlsx"
         wb2.load(path2);
-        xlnt_assert_equals(wb2.active_sheet().cell("A1").value<std::string>(), U8_CAST_LITERAL(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
+        xlnt_assert_equals(wb2.active_sheet().cell("A1").value<std::string>(), U8_TO_CHAR_PTR(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
 #endif
     }
 

--- a/tests/internal/serialization_test_suite.cpp
+++ b/tests/internal/serialization_test_suite.cpp
@@ -22,8 +22,6 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 
-#include <iostream>
-
 #include <xlnt/xlnt.hpp>
 #include <internal/locale_helpers.hpp>
 #include <helpers/path_helper.hpp>
@@ -31,6 +29,21 @@
 #include <helpers/test_suite.hpp>
 #include <helpers/xml_helper.hpp>
 #include <detail/serialization/xlsx_consumer.hpp>
+#include <detail/utils/string_helpers.hpp>
+
+// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
+// that partially implement certain features.
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
+#ifdef __has_include
+# if __has_include(<string_view>)
+#   include <string_view>
+# endif
+#endif
 
 class serialization_test_suite : public test_suite
 {
@@ -356,7 +369,7 @@ public:
         // L"/9_unicode_\u039B_\U0001F607.xlsx" gives the correct output
         const auto path = LSTRING_LITERAL(XLNT_TEST_DATA_DIR) L"/9_unicode_\u039B_\U0001F607.xlsx"; // L"/9_unicode_Λ_😇.xlsx"
         wb.load(path);
-        xlnt_assert_equals(wb.active_sheet().cell("A1").value<std::string>(), u8"un\u00EFc\u00F4d\u0117!"); // u8"unïcôdė!"
+        xlnt_assert_equals(wb.active_sheet().cell("A1").value<std::string>(), U8_CAST_CONST_LITERAL(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
 #endif
 
 #ifndef __MINGW32__
@@ -365,7 +378,7 @@ public:
         // u8"/9_unicode_\u039B_\U0001F607.xlsx" gives the correct output
         const auto path2 = U8STRING_LITERAL(XLNT_TEST_DATA_DIR) u8"/9_unicode_\u039B_\U0001F607.xlsx"; // u8"/9_unicode_Λ_😇.xlsx"
         wb2.load(path2);
-        xlnt_assert_equals(wb2.active_sheet().cell("A1").value<std::string>(), u8"un\u00EFc\u00F4d\u0117!"); // u8"unïcôdė!"
+        xlnt_assert_equals(wb2.active_sheet().cell("A1").value<std::string>(), U8_CAST_CONST_LITERAL(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
 #endif
     }
 
@@ -622,6 +635,13 @@ public:
         //return source_data == destination_data;
         return true;
     }
+
+#ifdef __cpp_lib_char8_t
+    bool round_trip_matches_rw(const xlnt::path &source, std::u8string_view password)
+    {
+        return round_trip_matches_rw(source, xlnt::detail::to_string_copy(password));
+    }
+#endif
 
     void test_round_trip_rw_minimal()
     {

--- a/tests/internal/serialization_test_suite.cpp
+++ b/tests/internal/serialization_test_suite.cpp
@@ -30,19 +30,10 @@
 #include <helpers/xml_helper.hpp>
 #include <detail/serialization/xlsx_consumer.hpp>
 #include <detail/utils/string_helpers.hpp>
+#include <xlnt/internal/features.hpp>
 
-// If available, allow using C++20 feature test macros for precise feature testing. Useful for compilers
-// that partially implement certain features.
-#ifdef __has_include
-# if __has_include(<version>)
-#   include <version>
-# endif
-#endif
-
-#ifdef __has_include
-# if __has_include(<string_view>)
-#   include <string_view>
-# endif
+#if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
+  #include <string_view>
 #endif
 
 class serialization_test_suite : public test_suite
@@ -369,7 +360,7 @@ public:
         // L"/9_unicode_\u039B_\U0001F607.xlsx" gives the correct output
         const auto path = LSTRING_LITERAL(XLNT_TEST_DATA_DIR) L"/9_unicode_\u039B_\U0001F607.xlsx"; // L"/9_unicode_Λ_😇.xlsx"
         wb.load(path);
-        xlnt_assert_equals(wb.active_sheet().cell("A1").value<std::string>(), U8_CAST_CONST_LITERAL(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
+        xlnt_assert_equals(wb.active_sheet().cell("A1").value<std::string>(), U8_CAST_LITERAL(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
 #endif
 
 #ifndef __MINGW32__
@@ -378,7 +369,7 @@ public:
         // u8"/9_unicode_\u039B_\U0001F607.xlsx" gives the correct output
         const auto path2 = U8STRING_LITERAL(XLNT_TEST_DATA_DIR) u8"/9_unicode_\u039B_\U0001F607.xlsx"; // u8"/9_unicode_Λ_😇.xlsx"
         wb2.load(path2);
-        xlnt_assert_equals(wb2.active_sheet().cell("A1").value<std::string>(), U8_CAST_CONST_LITERAL(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
+        xlnt_assert_equals(wb2.active_sheet().cell("A1").value<std::string>(), U8_CAST_LITERAL(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
 #endif
     }
 
@@ -636,7 +627,7 @@ public:
         return true;
     }
 
-#ifdef __cpp_lib_char8_t
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     bool round_trip_matches_rw(const xlnt::path &source, std::u8string_view password)
     {
         return round_trip_matches_rw(source, xlnt::detail::to_string_copy(password));

--- a/tests/internal/serialization_test_suite.cpp
+++ b/tests/internal/serialization_test_suite.cpp
@@ -603,7 +603,8 @@ public:
         return xml_helper::xlsx_archives_match(xlnt::detail::to_vector(source_stream), destination);
     }
 
-    bool round_trip_matches_rw(const xlnt::path &source, const std::string &password)
+    template <typename T>
+    bool round_trip_matches_rw(const xlnt::path &source, const T &password)
     {
 #ifdef _MSC_VER
         std::ifstream source_stream(source.wstring(), std::ios::binary);
@@ -617,22 +618,15 @@ public:
 
         std::vector<std::uint8_t> destination_data;
         //source_workbook.save(destination_data, password);
-        source_workbook.save("encrypted.xlsx", password);
+        source_workbook.save(xlnt::path("encrypted.xlsx"), password);
 
         //xlnt::workbook temp;
-        //temp.load("encrypted.xlsx", password);
+        //temp.load(xlnt::path("encrypted.xlsx"), password);
 
         //TODO: finish implementing encryption and uncomment this
         //return source_data == destination_data;
         return true;
     }
-
-#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
-    bool round_trip_matches_rw(const xlnt::path &source, std::u8string_view password)
-    {
-        return round_trip_matches_rw(source, xlnt::detail::to_string_copy(password));
-    }
-#endif
 
     void test_round_trip_rw_minimal()
     {

--- a/tests/internal/serialization_test_suite.cpp
+++ b/tests/internal/serialization_test_suite.cpp
@@ -53,6 +53,7 @@ public:
         register_test(test_decrypt_standard);
         register_test(test_decrypt_numbers);
         register_test(test_read_unicode_filename);
+        register_test(test_write_unicode_filename);
         register_test(test_comments);
         register_test(test_read_hyperlink);
         register_test(test_read_formulae);
@@ -378,6 +379,27 @@ public:
         const auto path2 = U8STRING_LITERAL(XLNT_TEST_DATA_DIR) u8"/9_unicode_\u039B_\U0001F607.xlsx"; // u8"/9_unicode_Λ_😇.xlsx"
         wb2.load(path2);
         xlnt_assert_equals(wb2.active_sheet().cell("A1").value<std::string>(), U8_TO_CHAR_PTR(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
+#endif
+    }
+
+    void test_write_unicode_filename()
+    {
+        // "/temp_unicode_Λ_😇.xlsx"
+        // "/temp_unicode_\u039B_\U0001F607.xlsx" gives the correct output
+#define TEMP_PATH "temp_unicode_\u039B_\U0001F607.xlsx"
+
+#ifdef _MSC_VER
+        xlnt::workbook wb;
+        const auto path = LSTRING_LITERAL(TEMP_PATH);
+        xlnt_assert_throws_nothing(wb.save(path));
+        xlnt_assert(xlnt::path(U8STRING_LITERAL(TEMP_PATH)).exists());
+#endif
+
+#ifndef __MINGW32__
+        xlnt::workbook wb2;
+        const auto path2 = U8STRING_LITERAL(TEMP_PATH);
+        xlnt_assert_throws_nothing(wb2.save(path2));
+        xlnt_assert(xlnt::path(path2).exists());
 #endif
     }
 

--- a/tests/internal/serialization_test_suite.cpp
+++ b/tests/internal/serialization_test_suite.cpp
@@ -49,6 +49,7 @@ public:
         register_test(test_load_non_xlsx);
         register_test(test_decrypt_agile);
         register_test(test_decrypt_libre_office);
+        register_test(test_decrypt_libre_office_constructor);
         register_test(test_decrypt_standard);
         register_test(test_decrypt_numbers);
         register_test(test_read_unicode_filename);
@@ -334,6 +335,13 @@ public:
         const auto path = path_helper::test_file("6_encrypted_libre.xlsx");
         xlnt_assert_throws(wb.load(path, "incorrect"), xlnt::exception);
         xlnt_assert_throws_nothing(wb.load(path, u8"\u043F\u0430\u0440\u043E\u043B\u044C")); // u8"пароль"
+    }
+
+    void test_decrypt_libre_office_constructor()
+    {
+        const auto path = path_helper::test_file("6_encrypted_libre.xlsx");
+        xlnt_assert_throws(xlnt::workbook(path, "incorrect"), xlnt::exception);
+        xlnt_assert_throws_nothing(xlnt::workbook(path, u8"\u043F\u0430\u0440\u043E\u043B\u044C")); // u8"пароль"
     }
 
     void test_decrypt_standard()

--- a/tests/internal/unicode_test_suite.cpp
+++ b/tests/internal/unicode_test_suite.cpp
@@ -53,7 +53,7 @@ public:
 
     void test_convert_utf8_to_utf16()
     {
-        const char *utf8 = LITERAL_AS_U8(UNICODE_TEST_STRING);
+        const char *utf8 = ENSURE_UTF8_LITERAL(UNICODE_TEST_STRING);
         std::u16string result = xlnt::detail::utf8_to_utf16(utf8);
         xlnt_assert_equals(result, U16STRING_LITERAL(UNICODE_TEST_STRING));
     }
@@ -69,7 +69,7 @@ public:
 
     void test_convert_utf8_to_utf32()
     {
-        const char *utf8 = LITERAL_AS_U8(UNICODE_TEST_STRING);
+        const char *utf8 = ENSURE_UTF8_LITERAL(UNICODE_TEST_STRING);
         std::u32string result = xlnt::detail::utf8_to_utf32(utf8);
         xlnt_assert_equals(result, U32STRING_LITERAL(UNICODE_TEST_STRING));
     }
@@ -87,7 +87,7 @@ public:
     {
         const char16_t *utf16 = U16STRING_LITERAL(UNICODE_TEST_STRING);
         std::string result = xlnt::detail::utf16_to_utf8(utf16);
-        xlnt_assert_equals(result, LITERAL_AS_U8(UNICODE_TEST_STRING));
+        xlnt_assert_equals(result, ENSURE_UTF8_LITERAL(UNICODE_TEST_STRING));
     }
 
 #if XLNT_HAS_FEATURE(U8_STRING_VIEW)
@@ -103,7 +103,7 @@ public:
     {
         const char32_t *utf32 = U32STRING_LITERAL(UNICODE_TEST_STRING);
         std::string result = xlnt::detail::utf32_to_utf8(utf32);
-        xlnt_assert_equals(result, LITERAL_AS_U8(UNICODE_TEST_STRING));
+        xlnt_assert_equals(result, ENSURE_UTF8_LITERAL(UNICODE_TEST_STRING));
     }
 
 #if XLNT_HAS_FEATURE(U8_STRING_VIEW)

--- a/tests/internal/unicode_test_suite.cpp
+++ b/tests/internal/unicode_test_suite.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2024-2025 xlnt-community
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE
+//
+// @license: http://www.opensource.org/licenses/mit-license.php
+// @author: see AUTHORS file
+
+#include <detail/unicode.hpp>
+#include <detail/utils/string_helpers.hpp>
+
+#include <helpers/test_suite.hpp>
+
+#define UNICODE_TEST_STRING "🤔🥳😇"
+
+class unicode_test_suite : public test_suite
+{
+public:
+    unicode_test_suite()
+    {
+        register_test(test_convert_utf8_to_utf16);
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+        register_test(test_convert_utf8_u8_to_utf16);
+#endif
+        register_test(test_convert_utf8_to_utf32);
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+        register_test(test_convert_utf8_u8_to_utf32);
+#endif
+        register_test(test_convert_utf16_to_utf8);
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+        register_test(test_convert_utf16_to_utf8_u8);
+#endif
+        register_test(test_convert_utf32_to_utf8);
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+        register_test(test_convert_utf32_to_utf8_u8);
+#endif
+    }
+
+    void test_convert_utf8_to_utf16()
+    {
+        const char *utf8 = LITERAL_AS_U8(UNICODE_TEST_STRING);
+        std::u16string result = xlnt::detail::utf8_to_utf16(utf8);
+        xlnt_assert_equals(result, U16STRING_LITERAL(UNICODE_TEST_STRING));
+    }
+
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+    void test_convert_utf8_u8_to_utf16()
+    {
+        const char8_t *utf8 = U8STRING_LITERAL(UNICODE_TEST_STRING);
+        std::u16string result = xlnt::detail::utf8_to_utf16(utf8);
+        xlnt_assert_equals(result, U16STRING_LITERAL(UNICODE_TEST_STRING));
+    }
+#endif
+
+    void test_convert_utf8_to_utf32()
+    {
+        const char *utf8 = LITERAL_AS_U8(UNICODE_TEST_STRING);
+        std::u32string result = xlnt::detail::utf8_to_utf32(utf8);
+        xlnt_assert_equals(result, U32STRING_LITERAL(UNICODE_TEST_STRING));
+    }
+
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+    void test_convert_utf8_u8_to_utf32()
+    {
+        const char8_t *utf8 = U8STRING_LITERAL(UNICODE_TEST_STRING);
+        std::u32string result = xlnt::detail::utf8_to_utf32(utf8);
+        xlnt_assert_equals(result, U32STRING_LITERAL(UNICODE_TEST_STRING));
+    }
+#endif
+
+    void test_convert_utf16_to_utf8()
+    {
+        const char16_t *utf16 = U16STRING_LITERAL(UNICODE_TEST_STRING);
+        std::string result = xlnt::detail::utf16_to_utf8(utf16);
+        xlnt_assert_equals(result, LITERAL_AS_U8(UNICODE_TEST_STRING));
+    }
+
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+    void test_convert_utf16_to_utf8_u8()
+    {
+        const char16_t *utf16 = U16STRING_LITERAL(UNICODE_TEST_STRING);
+        std::u8string result = xlnt::detail::utf16_to_utf8_u8(utf16);
+        xlnt_assert_equals(result, U8STRING_LITERAL(UNICODE_TEST_STRING));
+    }
+#endif
+
+    void test_convert_utf32_to_utf8()
+    {
+        const char32_t *utf32 = U32STRING_LITERAL(UNICODE_TEST_STRING);
+        std::string result = xlnt::detail::utf32_to_utf8(utf32);
+        xlnt_assert_equals(result, LITERAL_AS_U8(UNICODE_TEST_STRING));
+    }
+
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+    void test_convert_utf32_to_utf8_u8()
+    {
+        const char32_t *utf32 = U32STRING_LITERAL(UNICODE_TEST_STRING);
+        std::u8string result = xlnt::detail::utf32_to_utf8_u8(utf32);
+        xlnt_assert_equals(result, U8STRING_LITERAL(UNICODE_TEST_STRING));
+    }
+#endif
+};
+static unicode_test_suite x;

--- a/tests/styles/number_format_test_suite.cpp
+++ b/tests/styles/number_format_test_suite.cpp
@@ -23,6 +23,7 @@
 // @author: see AUTHORS file
 
 #include <iostream>
+#include <array>
 
 #include <helpers/test_suite.hpp>
 

--- a/tests/utils/path_test_suite.cpp
+++ b/tests/utils/path_test_suite.cpp
@@ -22,9 +22,8 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 
-#include <iostream>
-
 #include <xlnt/utils/path.hpp>
+#include <detail/utils/string_helpers.hpp>
 #include <helpers/path_helper.hpp>
 #include <helpers/temporary_file.hpp>
 #include <helpers/test_suite.hpp>
@@ -37,6 +36,10 @@ public:
         register_test(test_exists);
 #ifdef _MSC_VER
         register_test(test_msvc_empty_path_wide);
+#endif
+        register_test(test_append);
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+        register_test(test_append_u8);
 #endif
     }
 
@@ -63,5 +66,22 @@ public:
         xlnt_assert(path_wide.empty());
     }
 #endif
+
+    void test_append()
+    {
+        xlnt::path path("hello");
+        path = path.append("world");
+        xlnt_assert_equals(path.string(), "hello/world");
+    }
+
+#if XLNT_HAS_FEATURE(U8_STRING_VIEW)
+    void test_append_u8()
+    {
+        xlnt::path path(u8"🤔🥳😇");
+        path = path.append(u8"🍕🍟🍔");
+        xlnt_assert_equals(path.string(), U8_TO_CHAR_PTR(u8"🤔🥳😇/🍕🍟🍔"));
+    }
+#endif
+
 };
 static path_test_suite x;


### PR DESCRIPTION
Changes made by this PR:

1. Support `char8_t` and `std::u8string(_view)` in user-facing code to support `u8""` string literals in C++20 and newer.
2. Remove `std::aligned_storage` from `xlnt::optional` due to C++23 deprecation warnings.
3. Add experimental support for C++26 - no further changes were necessary (not yet, at least). I think we can use this to test new C++ compiler versions, but I would not guarantee C++26 support until it is officially released.
4. Set CI to use C++23. I think it's better to not use C++26 yet to avoid issues when new compiler versions are released.
5. Fix Unicode file paths on Windows when checking for existence of files and folders, and when reading a file into a string.


Note: instead of using `const std::u8string &` like we do with `std::string` in our current code, I chose to use `std::u8string_view` to avoid unnecessarily copying strings, as we currently do in many cases (which we cannot properly avoid except when using C strings (bad idea IMO) or by switching to C++17 as a minimum). We should also switch from `const std::string &` to `std::string_view` when switching to C++17 as a minimum in the future. But, for now, I simply assumed support for `std::string_view` (C++17) when using C++20 features, which is something that should hopefully always work.