### PR TITLE
Use C++23 for generating coverage report.

### DIFF
--- a/.circleci/continue_config_in.yml
+++ b/.circleci/continue_config_in.yml
@@ -42,13 +42,16 @@ jobs:
       skip-internal-tests:
         default: "OFF"
         type: string
+      warnings-as-errors:
+        default: "ON"
+        type: string
       image:
         default: PLACEHOLDER_IMAGE(gcc7_cmake3.9.5)
         type: string
     steps:
       - checkout
       - run: git submodule update --init --recursive
-      - run: cmake -D XLNT_ALL_WARNINGS_AS_ERRORS=ON -D XLNT_CXX_LANG=<< parameters.cxx-ver >> -D STATIC=<< parameters.static >> -D BENCHMARKS=<< parameters.benchmarks >> -D XLNT_MICROBENCH_ENABLED=<< parameters.micro-benchmarks >> -D TESTS=<< parameters.tests >> -D XLNT_SKIP_INTERNAL_TESTS=<< parameters.skip-internal-tests >> -D SAMPLES=<< parameters.samples >> -D COVERAGE=<< parameters.coverage >> -D CMAKE_BUILD_TYPE=<< parameters.build-type >> -D XLNT_USE_LOCALE_COMMA_DECIMAL_SEPARATOR=ON -D XLNT_LOCALE_COMMA_DECIMAL_SEPARATOR=de_DE -D XLNT_USE_LOCALE_ARABIC_DECIMAL_SEPARATOR=ON -D XLNT_LOCALE_ARABIC_DECIMAL_SEPARATOR=ps_AF .
+      - run: cmake -D XLNT_ALL_WARNINGS_AS_ERRORS=<< parameters.warnings-as-errors >> -D XLNT_CXX_LANG=<< parameters.cxx-ver >> -D STATIC=<< parameters.static >> -D BENCHMARKS=<< parameters.benchmarks >> -D XLNT_MICROBENCH_ENABLED=<< parameters.micro-benchmarks >> -D TESTS=<< parameters.tests >> -D XLNT_SKIP_INTERNAL_TESTS=<< parameters.skip-internal-tests >> -D SAMPLES=<< parameters.samples >> -D COVERAGE=<< parameters.coverage >> -D CMAKE_BUILD_TYPE=<< parameters.build-type >> -D XLNT_USE_LOCALE_COMMA_DECIMAL_SEPARATOR=ON -D XLNT_LOCALE_COMMA_DECIMAL_SEPARATOR=de_DE -D XLNT_USE_LOCALE_ARABIC_DECIMAL_SEPARATOR=ON -D XLNT_LOCALE_ARABIC_DECIMAL_SEPARATOR=ps_AF .
       - run: cmake --build . -- -j2
       - when:
           condition:
@@ -324,7 +327,9 @@ workflows:
     jobs:
       - build-gcc:
           name: samples-benchmarks-coverage-gcc
-          cxx-ver: "11"
+          image: PLACEHOLDER_IMAGE(gcc_cmake_latest)
+          cxx-ver: "23"
+          warnings-as-errors: "OFF"
           build-type: Debug
           static: "ON"
           samples: "ON"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(COMBINED_PROJECT TRUE)
 option(STATIC "Set to ON to build xlnt as a static library instead of a shared library" OFF)
 
 # C++ language standard to use
-set(XLNT_CXX_VALID_LANGS 11 14 17)
+set(XLNT_CXX_VALID_LANGS 11 14 17 20 23)
 set(XLNT_CXX_LANG "14" CACHE STRING "C++ language features to compile with")
 # enumerate allowed values for cmake gui
 set_property(CACHE XLNT_CXX_LANG PROPERTY STRINGS ${XLNT_CXX_VALID_LANGS})

--- a/tests/internal/serialization_test_suite.cpp
+++ b/tests/internal/serialization_test_suite.cpp
@@ -329,7 +329,7 @@ public:
         xlnt::workbook wb;
         const auto path = path_helper::test_file("6_encrypted_libre.xlsx");
         xlnt_assert_throws(wb.load(path, "incorrect"), xlnt::exception);
-        xlnt_assert_throws_nothing(wb.load(path, u8"\u043F\u0430\u0440\u043E\u043B\u044C")); // u8"пароль"
+        xlnt_assert_throws_nothing(wb.load(path, reinterpret_cast<const char*>(u8"\u043F\u0430\u0440\u043E\u043B\u044C"))); // u8"пароль"
     }
 
     void test_decrypt_standard()
@@ -363,9 +363,9 @@ public:
         xlnt::workbook wb2;
         // u8"/9_unicode_Λ_😇.xlsx" doesn't use 0xC3AA for the capital lambda...
         // u8"/9_unicode_\u039B_\U0001F607.xlsx" gives the correct output
-        const auto path2 = U8STRING_LITERAL(XLNT_TEST_DATA_DIR) u8"/9_unicode_\u039B_\U0001F607.xlsx"; // u8"/9_unicode_Λ_😇.xlsx"
+        const auto path2 = reinterpret_cast<const char*>(U8STRING_LITERAL(XLNT_TEST_DATA_DIR) u8"/9_unicode_\u039B_\U0001F607.xlsx"); // u8"/9_unicode_Λ_😇.xlsx"
         wb2.load(path2);
-        xlnt_assert_equals(wb2.active_sheet().cell("A1").value<std::string>(), u8"un\u00EFc\u00F4d\u0117!"); // u8"unïcôdė!"
+        xlnt_assert_equals(wb2.active_sheet().cell("A1").value<std::string>(), reinterpret_cast<const char*>(u8"un\u00EFc\u00F4d\u0117!")); // u8"unïcôdė!"
 #endif
     }
 
@@ -642,7 +642,7 @@ public:
     {
         // u8"/9_unicode_Λ_😇.xlsx" doesn't use 0xC3AA for the capital lambda...
         // u8"/9_unicode_\u039B_\U0001F607.xlsx" gives the correct output
-        xlnt_assert(round_trip_matches_rw(path_helper::test_file(u8"9_unicode_\u039B_\U0001F607.xlsx")));
+        xlnt_assert(round_trip_matches_rw(path_helper::test_file(reinterpret_cast<const char*>(u8"9_unicode_\u039B_\U0001F607.xlsx"))));
     }
 
     void test_round_trip_rw_comments_hyperlinks_formulae()
@@ -672,7 +672,7 @@ public:
 
     void test_round_trip_rw_encrypted_libre()
     {
-        xlnt_assert(round_trip_matches_rw(path_helper::test_file("6_encrypted_libre.xlsx"), u8"\u043F\u0430\u0440\u043E\u043B\u044C")); // u8"пароль"
+        xlnt_assert(round_trip_matches_rw(path_helper::test_file("6_encrypted_libre.xlsx"), reinterpret_cast<const char*>(u8"\u043F\u0430\u0440\u043E\u043B\u044C"))); // u8"пароль"
     }
 
     void test_round_trip_rw_encrypted_standard()


### PR DESCRIPTION
Using C++23 for coverage reporting, prepares the library for coverage testing of future post-C++11 features.

This PR makes as few changes as possible to ensure all coverage changes are due to the changed C++/compiler version used for generating the coverage report.

Better C++20/23 support will be added in PR #55 