### PR TITLE
Memory safety improvements

### DIFF
--- a/include/xlnt/cell/cell.hpp
+++ b/include/xlnt/cell/cell.hpp
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -32,6 +33,7 @@
 #include <xlnt/cell/cell_type.hpp>
 #include <xlnt/cell/index_types.hpp>
 #include <xlnt/cell/rich_text.hpp>
+#include <xlnt/types.hpp>
 
 namespace xlnt {
 
@@ -67,6 +69,8 @@ class xlsx_consumer;
 class xlsx_producer;
 
 struct cell_impl;
+struct format_impl;
+struct worksheet_impl;
 
 } // namespace detail
 
@@ -84,6 +88,11 @@ class XLNT_API cell
 {
 public:
     /// <summary>
+    /// The method for cloning cells.
+    /// </summary>
+    using clone_method = xlnt::clone_method;
+
+    /// <summary>
     /// Alias xlnt::cell_type to xlnt::cell::type since it looks nicer.
     /// </summary>
     using type = cell_type;
@@ -94,9 +103,15 @@ public:
     static const std::unordered_map<std::string, int> &error_codes();
 
     /// <summary>
-    /// Default copy constructor.
+    /// Delete the default zero-argument constructor.
     /// </summary>
-    cell(const cell &) = default;
+    cell() = delete;
+
+    /// <summary>
+    /// Creates a clone of this cell. A shallow copy will copy the cell's internal pointers,
+    /// while a deep copy will copy all the internal structures and create a full clone of the cell.
+    /// </summary>
+    cell clone(clone_method method) const;
 
     // value
 
@@ -619,18 +634,12 @@ public:
     // operators
 
     /// <summary>
-    /// Makes this cell interally point to rhs.
-    /// The cell data originally pointed to by this cell will be unchanged.
-    /// </summary>
-    cell &operator=(const cell &rhs);
-
-    /// <summary>
-    /// Returns true if this cell the same cell as comparand (compared by reference).
+    /// Returns true if this cell is the same cell as comparand (compared by reference).
     /// </summary>
     bool operator==(const cell &comparand) const;
 
     /// <summary>
-    /// Returns false if this cell the same cell as comparand (compared by reference).
+    /// Returns false if this cell is the same cell as comparand (compared by reference).
     /// </summary>
     bool operator!=(const cell &comparand) const;
 
@@ -648,19 +657,20 @@ private:
     class format modifiable_format();
 
     /// <summary>
-    /// Delete the default zero-argument constructor.
+    /// Returns a shared_ptr to the parent which is checked for validity.
+    /// If the pointer is invalid, an xlnt::invald_attribute exception is thrown.
     /// </summary>
-    cell() = delete;
+    std::shared_ptr<detail::worksheet_impl> get_parent_checked() const;
 
     /// <summary>
     /// Private constructor to create a cell from its implementation.
     /// </summary>
-    cell(detail::cell_impl *d);
+    cell(std::shared_ptr<detail::cell_impl> d);
 
     /// <summary>
     /// A pointer to this cell's implementation.
     /// </summary>
-    detail::cell_impl *d_ = nullptr;
+    std::shared_ptr<detail::cell_impl> d_;
 };
 
 /// <summary>

--- a/include/xlnt/cell/hyperlink.hpp
+++ b/include/xlnt/cell/hyperlink.hpp
@@ -25,6 +25,8 @@
 #pragma once
 
 #include <xlnt/xlnt_config.hpp>
+#include <xlnt/types.hpp>
+#include <memory>
 #include <string>
 
 namespace xlnt {
@@ -43,6 +45,34 @@ class relationship;
 class XLNT_API hyperlink
 {
 public:
+    /// <summary>
+    /// The method for cloning hyperlinks.
+    /// </summary>
+    using clone_method = xlnt::clone_method;
+
+    /// <summary>
+    /// Creates a clone of this hyperlink. A shallow copy will copy the hyperlink's internal pointers,
+    /// while a deep copy will copy all the internal structures and create a full clone of the hyperlink.
+    /// </summary>
+    hyperlink clone(clone_method method) const;
+
+    /// <summary>
+    /// Returns true if this hyperlink is equal to other. If compare_by_reference is true, the comparison
+    /// will only check that both hyperlinks point to the same internal hyperlink. Otherwise,
+    /// if compare_by_reference is false, all hyperlink properties are compared.
+    /// </summary>
+    bool compare(const hyperlink &other, bool compare_by_reference) const;
+
+    /// <summary>
+    /// Returns true if this hyperlink is the same hyperlink as comparand (compared by reference).
+    /// </summary>
+    bool operator==(const hyperlink &comparand) const;
+
+    /// <summary>
+    /// Returns false if this hyperlink is the same hyperlink as comparand (compared by reference).
+    /// </summary>
+    bool operator!=(const hyperlink &comparand) const;
+
     bool external() const;
     class relationship relationship() const;
     // external target
@@ -64,8 +94,8 @@ public:
 
 private:
     friend class cell;
-    hyperlink(detail::hyperlink_impl *d);
-    detail::hyperlink_impl *d_ = nullptr;
+    hyperlink(std::shared_ptr<detail::hyperlink_impl> d);
+    std::shared_ptr<detail::hyperlink_impl> d_;
 };
 
 } // namespace xlnt

--- a/include/xlnt/styles/conditional_format.hpp
+++ b/include/xlnt/styles/conditional_format.hpp
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/utils/optional.hpp>
+#include <xlnt/types.hpp>
 
 namespace xlnt {
 
@@ -91,14 +93,20 @@ class XLNT_API conditional_format
 {
 public:
     /// <summary>
+    /// The method for cloning conditional_formats.
+    /// </summary>
+    using clone_method = xlnt::clone_method;
+
+    /// <summary>
     /// Delete zero-argument constructor
     /// </summary>
     conditional_format() = delete;
 
     /// <summary>
-    /// Default copy constructor. Constructs a format using the same PIMPL as other.
+    /// Creates a clone of this conditional_format. A shallow copy will copy the conditional_format's internal pointers,
+    /// while a deep copy will copy all the internal structures and create a full clone of the conditional_format.
     /// </summary>
-    conditional_format(const conditional_format &other) = default;
+    conditional_format clone(clone_method method) const;
 
     // Formatting (xf) components
 
@@ -148,6 +156,13 @@ public:
     conditional_format font(const xlnt::font &new_font);
 
     /// <summary>
+    /// Returns true if this conditional_format is equal to other. If compare_by_reference is true, the comparison
+    /// will only check that both conditional_formats point to the same internal conditional_format. Otherwise,
+    /// if compare_by_reference is false, all conditional_format properties are compared.
+    /// </summary>
+    bool compare(const conditional_format &other, bool compare_by_reference) const;
+
+    /// <summary>
     /// Returns true if this format is equivalent to other.
     /// </summary>
     bool operator==(const conditional_format &other) const;
@@ -162,14 +177,20 @@ private:
     friend class detail::xlsx_consumer;
 
     /// <summary>
-    ///
+    /// Returns a shared_ptr to the parent which is checked for validity.
+    /// If the pointer is invalid, an xlnt::invald_attribute exception is thrown.
     /// </summary>
-    conditional_format(detail::conditional_format_impl *d);
+    std::shared_ptr<detail::stylesheet> get_parent_checked() const;
 
     /// <summary>
     ///
     /// </summary>
-    detail::conditional_format_impl *d_ = nullptr;
+    conditional_format(std::shared_ptr<detail::conditional_format_impl> d);
+
+    /// <summary>
+    ///
+    /// </summary>
+    std::shared_ptr<detail::conditional_format_impl> d_;
 };
 
 } // namespace xlnt

--- a/include/xlnt/styles/format.hpp
+++ b/include/xlnt/styles/format.hpp
@@ -24,9 +24,12 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
+#include <xlnt/utils/optional.hpp>
 #include <xlnt/xlnt_config.hpp>
+#include <xlnt/types.hpp>
 
 namespace xlnt {
 
@@ -38,9 +41,6 @@ class font;
 class number_format;
 class protection;
 class style;
-
-template <typename T>
-class optional;
 
 namespace detail {
 
@@ -57,6 +57,34 @@ class xlsx_consumer;
 class XLNT_API format
 {
 public:
+    /// <summary>
+    /// The method for cloning formats.
+    /// </summary>
+    using clone_method = xlnt::clone_method;
+
+    /// <summary>
+    /// Creates a clone of this format. A shallow copy will copy the format's internal pointers,
+    /// while a deep copy will copy all the internal structures and create a full clone of the format.
+    /// </summary>
+    format clone(clone_method method) const;
+
+    /// <summary>
+    /// Returns true if this format is equal to other. If compare_by_reference is true, the comparison
+    /// will only check that both formats point to the same internal format. Otherwise,
+    /// if compare_by_reference is false, all format properties are compared.
+    /// </summary>
+    bool compare(const format &other, bool compare_by_reference) const;
+
+    /// <summary>
+    /// Returns true if this format is equivalent to other.
+    /// </summary>
+    bool operator==(const format &other) const;
+
+    /// <summary>
+    /// Returns true if this format is not equivalent to other.
+    /// </summary>
+    bool operator!=(const format &other) const;
+
     /// <summary>
     /// Returns the alignment of this format.
     /// </summary>
@@ -222,14 +250,20 @@ private:
     friend class cell;
 
     /// <summary>
+    /// Returns a shared_ptr to the parent which is checked for validity.
+    /// If the pointer is invalid, an xlnt::invald_attribute exception is thrown.
+    /// </summary>
+    std::shared_ptr<detail::stylesheet> get_parent_checked() const;
+
+    /// <summary>
     /// Constructs a format from an impl pointer.
     /// </summary>
-    format(detail::format_impl *d);
+    format(std::shared_ptr<detail::format_impl> d);
 
     /// <summary>
     /// The internal implementation of this format
     /// </summary>
-    detail::format_impl *d_ = nullptr;
+    std::shared_ptr<detail::format_impl> d_;
 };
 
 } // namespace xlnt

--- a/include/xlnt/styles/style.hpp
+++ b/include/xlnt/styles/style.hpp
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/utils/optional.hpp>
+#include <xlnt/types.hpp>
 
 namespace xlnt {
 
@@ -56,14 +58,20 @@ class XLNT_API style
 {
 public:
     /// <summary>
+    /// The method for cloning styles.
+    /// </summary>
+    using clone_method = xlnt::clone_method;
+
+    /// <summary>
     /// Delete zero-argument constructor
     /// </summary>
     style() = delete;
 
     /// <summary>
-    /// Default copy constructor. Constructs a style using the same PIMPL as other.
+    /// Creates a clone of this style. A shallow copy will copy the style's internal pointers,
+    /// while a deep copy will copy all the internal structures and create a full clone of the style.
     /// </summary>
-    style(const style &other) = default;
+    style clone(clone_method method) const;
 
     /// <summary>
     /// Returns the name of this style.
@@ -234,6 +242,13 @@ public:
     void quote_prefix(bool quote);
 
     /// <summary>
+    /// Returns true if this style is equal to other. If compare_by_reference is true, the comparison
+    /// will only check that both styles point to the same internal style. Otherwise,
+    /// if compare_by_reference is false, all style properties are compared.
+    /// </summary>
+    bool compare(const style &other, bool compare_by_reference) const;
+
+    /// <summary>
     /// Returns true if this style is equivalent to other.
     /// </summary>
     bool operator==(const style &other) const;
@@ -248,14 +263,20 @@ private:
     friend class detail::xlsx_consumer;
 
     /// <summary>
+    /// Returns a shared_ptr to the parent which is checked for validity.
+    /// If the pointer is invalid, an xlnt::invald_attribute exception is thrown.
+    /// </summary>
+    std::shared_ptr<detail::stylesheet> get_parent_checked() const;
+
+    /// <summary>
     /// Constructs a style from an impl pointer.
     /// </summary>
-    style(detail::style_impl *d);
+    style(std::shared_ptr<detail::style_impl> d);
 
     /// <summary>
     /// The internal implementation of this style
     /// </summary>
-    detail::style_impl *d_ = nullptr;
+    std::shared_ptr<detail::style_impl> d_;
 };
 
 } // namespace xlnt

--- a/include/xlnt/types.hpp
+++ b/include/xlnt/types.hpp
@@ -1,4 +1,3 @@
-// Copyright (c) 2018-2022 Thomas Fussell
 // Copyright (c) 2024-2025 xlnt-community
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,35 +23,16 @@
 
 #pragma once
 
-#include <string>
-
-#include <xlnt/packaging/relationship.hpp>
-#include <xlnt/utils/optional.hpp>
-
 namespace xlnt {
-namespace detail {
 
-// [serialised]
-struct hyperlink_impl
+/// <summary>
+/// The method for cloning XLNT classes. Useful for classes
+/// that respect the XLNT memory model, which do shallow copies by default.
+/// </summary>
+enum class clone_method
 {
-    xlnt::relationship relationship;
-    xlnt::optional<std::string> location;
-    xlnt::optional<std::string> tooltip;
-    xlnt::optional<std::string> display;
+    deep_copy,
+    shallow_copy
 };
 
-inline bool operator==(const hyperlink_impl &lhs, const hyperlink_impl &rhs)
-{
-    return lhs.relationship == rhs.relationship
-        && lhs.location == rhs.location
-        && lhs.tooltip == rhs.tooltip
-        && lhs.display == rhs.display;
-}
-
-inline bool operator!=(const hyperlink_impl &lhs, const hyperlink_impl &rhs)
-{
-    return !(lhs == rhs);
-}
-
-} // namespace detail
 } // namespace xlnt

--- a/include/xlnt/utils/exceptions.hpp
+++ b/include/xlnt/utils/exceptions.hpp
@@ -52,7 +52,7 @@ public:
     /// <summary>
     /// Destructor
     /// </summary>
-    ~exception() override;
+    ~exception() override = default;
 
     /// <summary>
     /// Sets the message after the xlnt::exception is constructed. This can show

--- a/include/xlnt/utils/optional.hpp
+++ b/include/xlnt/utils/optional.hpp
@@ -70,6 +70,9 @@ class optional
     }
 
 public:
+
+    using value_type = T;
+
     /// <summary>
     /// Default contructor. is_set() will be false initially.
     /// </summary>

--- a/include/xlnt/workbook/workbook.hpp
+++ b/include/xlnt/workbook/workbook.hpp
@@ -35,6 +35,7 @@
 
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/internal/features.hpp>
+#include <xlnt/types.hpp>
 
 #if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
   #include <string_view>
@@ -99,11 +100,7 @@ public:
     /// <summary>
     /// The method for cloning workbooks.
     /// </summary>
-    enum class clone_method
-    {
-        deep_copy,
-        shallow_copy
-    };
+    using clone_method = xlnt::clone_method;
 
     /// <summary>
     /// typedef for the iterator used for iterating through this workbook
@@ -191,9 +188,7 @@ public:
     workbook(const workbook &other) = default;
 
     /// <summary>
-    /// Destroys this workbook, deallocating all internal storage space. Any pimpl
-    /// wrapper classes (e.g. cell) pointing into this workbook will be invalid
-    /// after this is executed.
+    /// Destroys this workbook, deallocating all internal storage space.
     /// </summary>
     ~workbook() = default;
 

--- a/include/xlnt/worksheet/range.hpp
+++ b/include/xlnt/worksheet/range.hpp
@@ -82,7 +82,7 @@ public:
     /// <summary>
     /// Desctructor
     /// </summary>
-    ~range();
+    ~range() = default;
 
     /// <summary>
     /// Default copy constructor.

--- a/include/xlnt/worksheet/range_iterator.hpp
+++ b/include/xlnt/worksheet/range_iterator.hpp
@@ -258,7 +258,7 @@ private:
     /// <summary>
     /// The implementation of the worksheet this iterator points to
     /// </summary>
-    detail::worksheet_impl *ws_ = nullptr;
+    std::weak_ptr<detail::worksheet_impl> ws_;
 
     /// <summary>
     /// The first cell in the current row or column this iterator points to

--- a/include/xlnt/worksheet/worksheet.hpp
+++ b/include/xlnt/worksheet/worksheet.hpp
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <iterator>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -35,6 +36,7 @@
 #include <xlnt/worksheet/page_margins.hpp>
 #include <xlnt/worksheet/page_setup.hpp>
 #include <xlnt/worksheet/sheet_view.hpp>
+#include <xlnt/types.hpp>
 
 namespace xlnt {
 
@@ -76,6 +78,11 @@ class XLNT_API worksheet
 {
 public:
     /// <summary>
+    /// The method for cloning worksheets.
+    /// </summary>
+    using clone_method = xlnt::clone_method;
+
+    /// <summary>
     /// Iterate over a non-const worksheet with an iterator of this type.
     /// </summary>
     using iterator = range_iterator;
@@ -98,12 +105,28 @@ public:
     /// <summary>
     /// Construct a null worksheet. No methods should be called on such a worksheet.
     /// </summary>
-    worksheet();
+    worksheet() = default;
+
+    /// <summary>
+    /// Destructs a worksheet.
+    /// </summary>
+    ~worksheet() = default;
 
     /// <summary>
     /// Copy constructor. This worksheet will point to the same memory as rhs's worksheet.
     /// </summary>
-    worksheet(const worksheet &rhs);
+    worksheet(const worksheet &rhs) = default;
+
+    /// <summary>
+    /// Move constructor. Constructs a worksheet from existing worksheet, other.
+    /// </summary>
+    worksheet(worksheet &&other) = default;
+
+    /// <summary>
+    /// Creates a clone of this worksheet. A shallow copy will copy the worksheet's internal pointers,
+    /// while a deep copy will copy all the internal structures and create a full clone of the worksheet.
+    /// </summary>
+    worksheet clone(clone_method method) const;
 
     /// <summary>
     /// Returns the workbook this worksheet is owned by.
@@ -495,7 +518,12 @@ public:
     /// <summary>
     /// Sets the internal pointer of this worksheet object to point to other.
     /// </summary>
-    void operator=(const worksheet &other);
+    worksheet &operator=(const worksheet &other) = default;
+
+    /// <summary>
+    /// Sets the internal pointer of this worksheet object to point to other.
+    /// </summary>
+    worksheet &operator=(worksheet &&other) = default;
 
     /// <summary>
     /// Convenience method for worksheet::cell method.
@@ -809,7 +837,17 @@ private:
     /// <summary>
     /// Constructs a worksheet impl wrapper from d.
     /// </summary>
-    worksheet(detail::worksheet_impl *d);
+    worksheet(std::shared_ptr<detail::worksheet_impl> d);
+
+    /// <summary>
+    /// Constructs a worksheet impl wrapper from d.
+    /// </summary>
+    worksheet(std::weak_ptr<detail::worksheet_impl> d);
+
+    /// <summary>
+    /// Internal function to set the impl.
+    /// </summary>
+    void set_impl(std::shared_ptr<detail::worksheet_impl> impl);
 
     /// <summary>
     /// Creates a comments part in the manifest as a relationship target of this sheet.
@@ -840,7 +878,7 @@ private:
     /// <summary>
     /// The pointer to this sheet's implementation.
     /// </summary>
-    detail::worksheet_impl *d_ = nullptr;
+    std::shared_ptr<detail::worksheet_impl> d_;
 };
 
 } // namespace xlnt

--- a/source/cell/hyperlink.cpp
+++ b/source/cell/hyperlink.cpp
@@ -29,9 +29,48 @@
 
 namespace xlnt {
 
-hyperlink::hyperlink(detail::hyperlink_impl *d)
-    : d_(d)
+hyperlink::hyperlink(std::shared_ptr<detail::hyperlink_impl> d)
+    : d_(std::move(d))
 {
+    if (d_ == nullptr)
+    {
+        throw xlnt::invalid_attribute("xlnt::hyperlink: invalid hyperlink_impl pointer");
+    }
+}
+
+hyperlink hyperlink::clone(clone_method method) const
+{
+    switch (method)
+    {
+    case clone_method::deep_copy:
+        return hyperlink(std::make_shared<detail::hyperlink_impl>(*d_));
+    case clone_method::shallow_copy:
+        return hyperlink(d_);
+    default:
+        throw xlnt::invalid_parameter("clone method not supported");
+    }
+}
+
+bool hyperlink::compare(const hyperlink &other, bool compare_by_reference) const
+{
+    if (compare_by_reference)
+    {
+        return d_ == other.d_;
+    }
+    else
+    {
+        return *d_ == *other.d_;
+    }
+}
+
+bool hyperlink::operator==(const hyperlink &comparand) const
+{
+    return compare(comparand, true);
+}
+
+bool hyperlink::operator!=(const hyperlink &comparand) const
+{
+    return !(*this == comparand);
 }
 
 relationship hyperlink::relationship() const

--- a/source/detail/implementations/conditional_format_impl.hpp
+++ b/source/detail/implementations/conditional_format_impl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 
 #include <xlnt/styles/conditional_format.hpp>
 #include <xlnt/utils/optional.hpp>
@@ -19,8 +20,8 @@ struct worksheet_impl;
 
 struct conditional_format_impl
 {
-	stylesheet *parent = nullptr;
-    worksheet_impl *target_sheet = nullptr;
+	std::weak_ptr<stylesheet> parent;
+    std::weak_ptr<worksheet_impl> target_sheet;
 
     bool operator==(const conditional_format_impl& rhs) const
     {

--- a/source/detail/implementations/format_impl.hpp
+++ b/source/detail/implementations/format_impl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 
 #include <detail/xlnt_config_impl.hpp>
 
@@ -27,7 +28,7 @@ struct stylesheet;
 
 struct format_impl
 {
-	stylesheet *parent = nullptr;
+	std::weak_ptr<stylesheet> parent;
 
 	std::size_t id = 0;
 
@@ -70,6 +71,11 @@ struct format_impl
             && left.pivot_button_ == right.pivot_button_
             && left.quote_prefix_ == right.quote_prefix_
             && left.style == right.style;
+    }
+
+    friend bool operator!=(const format_impl &left, const format_impl &right)
+    {
+        return !(left == right);
     }
 };
 

--- a/source/detail/implementations/style_impl.hpp
+++ b/source/detail/implementations/style_impl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <string>
 
 #include <xlnt/utils/optional.hpp>
@@ -20,7 +21,7 @@ struct stylesheet;
 
 struct style_impl
 {
-	stylesheet *parent = nullptr;
+	std::weak_ptr<stylesheet> parent;
 
     bool operator==(const style_impl& rhs) const
     {

--- a/source/detail/implementations/workbook_impl.cpp
+++ b/source/detail/implementations/workbook_impl.cpp
@@ -1,0 +1,136 @@
+// Copyright (c) 2014-2022 Thomas Fussell
+// Copyright (c) 2024-2025 xlnt-community
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE
+//
+// @license: http://www.opensource.org/licenses/mit-license.php
+// @author: see AUTHORS file
+
+#include <detail/implementations/workbook_impl.hpp>
+#include <detail/implementations/worksheet_impl.hpp>
+
+namespace xlnt {
+namespace detail {
+
+workbook_impl::workbook_impl(const workbook_impl &other)
+    : active_sheet_index_(other.active_sheet_index_),
+        shared_strings_ids_(other.shared_strings_ids_),
+        shared_strings_values_(other.shared_strings_values_),
+        stylesheet_(other.stylesheet_ == nullptr ? nullptr : std::make_shared<stylesheet>(*other.stylesheet_)),
+        manifest_(other.manifest_),
+        theme_(other.theme_),
+        core_properties_(other.core_properties_),
+        extended_properties_(other.extended_properties_),
+        custom_properties_(other.custom_properties_),
+        view_(other.view_),
+        code_name_(other.code_name_),
+        file_version_(other.file_version_)
+{
+    worksheets_.reserve(other.worksheets_.size());
+    for (const auto &worksheet_ptr : other.worksheets_)
+    {
+        worksheets_.emplace_back(worksheet_ptr->clone());
+    }
+}
+
+workbook_impl &workbook_impl::operator=(const workbook_impl &other)
+{
+    active_sheet_index_ = other.active_sheet_index_;
+    worksheets_.clear();
+    worksheets_.reserve(other.worksheets_.size());
+    for (const auto &worksheet_ptr : other.worksheets_)
+    {
+        worksheets_.emplace_back(worksheet_ptr->clone());
+    }
+
+    if (other.stylesheet_ == nullptr)
+    {
+        stylesheet_ = nullptr;
+    }
+    else if (stylesheet_ == nullptr)
+    {
+        stylesheet_ = std::make_shared<stylesheet>(*other.stylesheet_);
+    }
+    else
+    {
+        *stylesheet_ = *other.stylesheet_;
+    }
+
+    shared_strings_ids_ = other.shared_strings_ids_;
+    shared_strings_values_ = other.shared_strings_values_;
+    theme_ = other.theme_;
+    manifest_ = other.manifest_;
+
+    sheet_title_rel_id_map_ = other.sheet_title_rel_id_map_;
+    sheet_hidden_ = other.sheet_hidden_;
+    view_ = other.view_;
+    code_name_ = other.code_name_;
+    file_version_ = other.file_version_;
+
+    core_properties_ = other.core_properties_;
+    extended_properties_ = other.extended_properties_;
+    custom_properties_ = other.custom_properties_;
+
+    return *this;
+}
+
+bool workbook_impl::operator==(const workbook_impl &other) const
+{
+    // not comparing abs_path_
+    if (worksheets_.size() != other.worksheets_.size())
+    {
+        return false;
+    }
+    else
+    {
+        auto it_this = worksheets_.begin();
+        auto it_other = other.worksheets_.begin();
+        for (; it_this != worksheets_.end() && it_other != other.worksheets_.end(); ++it_this, ++it_other)
+        {
+            if (**it_this != **it_other)
+            {
+                return false;
+            }
+        }
+    }
+
+    return active_sheet_index_ == other.active_sheet_index_
+        && shared_strings_ids_ == other.shared_strings_ids_
+        && ((stylesheet_ == nullptr && other.stylesheet_ == nullptr) || (stylesheet_ != nullptr && other.stylesheet_ != nullptr && *stylesheet_ == *other.stylesheet_))
+        && base_date_ == other.base_date_
+        && title_ == other.title_
+        && manifest_ == other.manifest_
+        && theme_ == other.theme_
+        && images_ == other.images_
+        && binaries_ == other.binaries_
+        && core_properties_ == other.core_properties_
+        && extended_properties_ == other.extended_properties_
+        && custom_properties_ == other.custom_properties_
+        && sheet_title_rel_id_map_ == other.sheet_title_rel_id_map_
+        && sheet_hidden_ == other.sheet_hidden_
+        && view_ == other.view_
+        && code_name_ == other.code_name_
+        && file_version_ == other.file_version_
+        && calculation_properties_ == other.calculation_properties_
+        && arch_id_flags_ == other.arch_id_flags_
+        && extensions_ == other.extensions_;
+}
+
+} // namespace detail
+} // namespace xlnt

--- a/source/detail/implementations/workbook_impl.hpp
+++ b/source/detail/implementations/workbook_impl.hpp
@@ -23,13 +23,13 @@
 // @author: see AUTHORS file
 #pragma once
 
-#include <list>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include <detail/implementations/stylesheet.hpp>
 #include <detail/implementations/worksheet_impl.hpp>
+#include <detail/xlnt_config_impl.hpp>
 #include <xlnt/packaging/ext_list.hpp>
 #include <xlnt/packaging/manifest.hpp>
 #include <xlnt/utils/datetime.hpp>
@@ -46,77 +46,17 @@ namespace detail {
 
 struct worksheet_impl;
 
-struct workbook_impl
+struct XLNT_API_INTERNAL workbook_impl
 {
-    workbook_impl() : base_date_(calendar::windows_1900)
-    {
-    }
+    workbook_impl() = default;
+    ~workbook_impl() = default;
+    workbook_impl(workbook_impl &&other) noexcept = default;
+    workbook_impl &operator=(workbook_impl &&other) noexcept = default;
 
-    workbook_impl(const workbook_impl &other)
-        : active_sheet_index_(other.active_sheet_index_),
-          worksheets_(other.worksheets_),
-          shared_strings_ids_(other.shared_strings_ids_),
-          shared_strings_values_(other.shared_strings_values_),
-          stylesheet_(other.stylesheet_),
-          manifest_(other.manifest_),
-          theme_(other.theme_),
-          core_properties_(other.core_properties_),
-          extended_properties_(other.extended_properties_),
-          custom_properties_(other.custom_properties_),
-          view_(other.view_),
-          code_name_(other.code_name_),
-          file_version_(other.file_version_)
-    {
-    }
+    workbook_impl(const workbook_impl &other);
+    workbook_impl &operator=(const workbook_impl &other);
 
-    workbook_impl &operator=(const workbook_impl &other)
-    {
-        active_sheet_index_ = other.active_sheet_index_;
-        worksheets_.clear();
-        std::copy(other.worksheets_.begin(), other.worksheets_.end(), back_inserter(worksheets_));
-        shared_strings_ids_ = other.shared_strings_ids_;
-        shared_strings_values_ = other.shared_strings_values_;
-        theme_ = other.theme_;
-        manifest_ = other.manifest_;
-
-        sheet_title_rel_id_map_ = other.sheet_title_rel_id_map_;
-        sheet_hidden_ = other.sheet_hidden_;
-        view_ = other.view_;
-        code_name_ = other.code_name_;
-        file_version_ = other.file_version_;
-
-        core_properties_ = other.core_properties_;
-        extended_properties_ = other.extended_properties_;
-        custom_properties_ = other.custom_properties_;
-
-        return *this;
-    }
-
-    bool operator==(const workbook_impl &other) const
-    {
-        // not comparing abs_path_
-        return active_sheet_index_ == other.active_sheet_index_
-            && worksheets_ == other.worksheets_
-            && shared_strings_ids_ == other.shared_strings_ids_
-            && stylesheet_ == other.stylesheet_
-            && base_date_ == other.base_date_
-            && title_ == other.title_
-            && manifest_ == other.manifest_
-            && theme_ == other.theme_
-            && images_ == other.images_
-            && binaries_ == other.binaries_
-            && core_properties_ == other.core_properties_
-            && extended_properties_ == other.extended_properties_
-            && custom_properties_ == other.custom_properties_
-            && sheet_title_rel_id_map_ == other.sheet_title_rel_id_map_
-            && sheet_hidden_ == other.sheet_hidden_
-            && view_ == other.view_
-            && code_name_ == other.code_name_
-            && file_version_ == other.file_version_
-            && calculation_properties_ == other.calculation_properties_
-            && arch_id_flags_ == other.arch_id_flags_
-            && extensions_ == other.extensions_;
-    }
+    bool operator==(const workbook_impl &other) const;
 
     bool operator!=(const workbook_impl &other) const
     {
@@ -125,13 +65,13 @@ struct workbook_impl
 
     optional<std::size_t> active_sheet_index_;
 
-    std::list<worksheet_impl> worksheets_;
+    std::vector<std::shared_ptr<worksheet_impl>> worksheets_;
     std::unordered_map<rich_text, std::size_t, rich_text_hash> shared_strings_ids_;
     std::vector<rich_text> shared_strings_values_;
 
-    optional<stylesheet> stylesheet_;
+    std::shared_ptr<stylesheet> stylesheet_;
 
-    calendar base_date_;
+    calendar base_date_ = calendar::windows_1900;
     optional<std::string> title_;
 
     manifest manifest_;

--- a/source/detail/serialization/xlsx_consumer.hpp
+++ b/source/detail/serialization/xlsx_consumer.hpp
@@ -433,12 +433,12 @@ private:
 
     bool streaming_ = false;
 
-    std::unique_ptr<detail::cell_impl> streaming_cell_;
+    std::shared_ptr<detail::cell_impl> streaming_cell_;
 
     std::unordered_map<int, std::string> shared_formulae_;
     std::unordered_map<std::string, std::string> array_formulae_;
 
-    detail::worksheet_impl *current_worksheet_ = nullptr;
+    std::shared_ptr<detail::worksheet_impl> current_worksheet_;
 
     std::vector<defined_name> defined_names_;
 };

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -247,11 +247,7 @@ private:
 
     bool streaming_ = false;
 
-    std::unique_ptr<detail::cell_impl> streaming_cell_;
-
-    detail::cell_impl *current_cell_ = nullptr;
-
-    detail::worksheet_impl *current_worksheet_ = nullptr;
+    std::shared_ptr<detail::worksheet_impl> current_worksheet_;
 };
 
 } // namespace detail

--- a/source/utils/exceptions.cpp
+++ b/source/utils/exceptions.cpp
@@ -33,8 +33,6 @@ exception::exception(const std::string &message)
     this->message(message);
 }
 
-exception::~exception() = default;
-
 void exception::message(const std::string &message)
 {
     message_ = message;

--- a/source/workbook/streaming_workbook_reader.cpp
+++ b/source/workbook/streaming_workbook_reader.cpp
@@ -98,9 +98,9 @@ void streaming_workbook_reader::begin_worksheet(const std::string &title)
 
     for (auto &impl : workbook_->impl().worksheets_)
     {
-        if (impl.title_ == title)
+        if (impl->title_ == title)
         {
-            consumer_->current_worksheet_ = &impl;
+            consumer_->current_worksheet_ = impl;
         }
     }
 

--- a/source/workbook/streaming_workbook_writer.cpp
+++ b/source/workbook/streaming_workbook_writer.cpp
@@ -101,9 +101,7 @@ void streaming_workbook_writer::open(std::ostream &stream)
     workbook_.reset(new workbook());
     producer_.reset(new detail::xlsx_producer(*workbook_));
     producer_->open(stream);
-    producer_->current_worksheet_ = new detail::worksheet_impl(workbook_.get(), 1, "Sheet1");
-    producer_->current_cell_ = new detail::cell_impl();
-    producer_->current_cell_->parent_ = producer_->current_worksheet_;
+    producer_->current_worksheet_ = std::make_shared<detail::worksheet_impl>(workbook_.get(), 1, "Sheet1");
 }
 
 } // namespace xlnt

--- a/source/workbook/workbook.cpp
+++ b/source/workbook/workbook.cpp
@@ -452,8 +452,16 @@ workbook workbook::empty()
 
     wb.theme(xlnt::theme());
 
-    wb.d_->stylesheet_ = detail::stylesheet();
-    auto &stylesheet = wb.d_->stylesheet_.get();
+    if (wb.d_->stylesheet_ == nullptr)
+    {
+        wb.d_->stylesheet_ = std::make_shared<detail::stylesheet>();
+    }
+    else
+    {
+        *wb.d_->stylesheet_ = detail::stylesheet();
+    }
+
+    auto &stylesheet = *wb.d_->stylesheet_;
     stylesheet.parent = wb.d_;
 
     auto default_border = border()
@@ -462,7 +470,7 @@ workbook workbook::empty()
                               .side(border_side::start, border::border_property())
                               .side(border_side::end, border::border_property())
                               .side(border_side::diagonal, border::border_property());
-    wb.d_->stylesheet_.get().borders.push_back(default_border);
+    wb.d_->stylesheet_->borders.push_back(default_border);
 
     auto default_fill = fill(pattern_fill()
                                  .type(pattern_fill_type::none));
@@ -570,7 +578,7 @@ void workbook::set_impl(std::shared_ptr<detail::workbook_impl> impl)
 {
     if (impl == nullptr)
     {
-        throw xlnt::invalid_parameter("invalid workbook pointer");
+        throw xlnt::invalid_attribute("xlnt::workbook: invalid workbook pointer");
     }
 
     d_ = std::move(impl);
@@ -680,9 +688,9 @@ const worksheet workbook::sheet_by_title(const std::string &title) const
 {
     for (auto &impl : d_->worksheets_)
     {
-        if (impl.title_ == title)
+        if (impl->title_ == title)
         {
-            return worksheet(&impl);
+            return worksheet(impl);
         }
     }
 
@@ -693,9 +701,9 @@ worksheet workbook::sheet_by_title(const std::string &title)
 {
     for (auto &impl : d_->worksheets_)
     {
-        if (impl.title_ == title)
+        if (impl->title_ == title)
         {
-            return worksheet(&impl);
+            return worksheet(impl);
         }
     }
 
@@ -709,14 +717,7 @@ worksheet workbook::sheet_by_index(std::size_t index)
         throw invalid_parameter();
     }
 
-    auto iter = d_->worksheets_.begin();
-
-    for (std::size_t i = 0; i < index; ++i)
-    {
-        ++iter;
-    }
-
-    return worksheet(&*iter);
+    return worksheet(d_->worksheets_[index]);
 }
 
 const worksheet workbook::sheet_by_index(std::size_t index) const
@@ -726,22 +727,16 @@ const worksheet workbook::sheet_by_index(std::size_t index) const
         throw invalid_parameter();
     }
 
-    auto iter = d_->worksheets_.begin();
-
-    for (std::size_t i = 0; i < index; ++i, ++iter)
-    {
-    }
-
-    return worksheet(&*iter);
+    return worksheet(d_->worksheets_[index]);
 }
 
 worksheet workbook::sheet_by_id(std::size_t id)
 {
     for (auto &impl : d_->worksheets_)
     {
-        if (impl.id_ == id)
+        if (impl->id_ == id)
         {
-            return worksheet(&impl);
+            return worksheet(impl);
         }
     }
 
@@ -752,9 +747,9 @@ const worksheet workbook::sheet_by_id(std::size_t id) const
 {
     for (auto &impl : d_->worksheets_)
     {
-        if (impl.id_ == id)
+        if (impl->id_ == id)
         {
-            return worksheet(&impl);
+            return worksheet(impl);
         }
     }
 
@@ -768,7 +763,7 @@ bool workbook::sheet_hidden_by_index(std::size_t index) const
         throw invalid_parameter();
     }
 
-    return d_->sheet_hidden_.at(index);
+    return d_->sheet_hidden_[index];
 }
 
 worksheet workbook::active_sheet()
@@ -809,7 +804,7 @@ worksheet workbook::create_sheet()
     {
         sheet_id = std::max(sheet_id, ws.id() + 1);
     }
-    d_->worksheets_.push_back(detail::worksheet_impl(this, sheet_id, title));
+    d_->worksheets_.emplace_back(std::make_shared<detail::worksheet_impl>(this, sheet_id, title));
     // unique sheet file name
     auto workbook_rel = d_->manifest_.relationship(path("/"), relationship_type::office_document);
     auto workbook_files = d_->manifest_.relationships(workbook_rel.target().path());
@@ -837,18 +832,19 @@ worksheet workbook::create_sheet()
     update_sheet_properties();
     reorder_relationships();
 
-    return worksheet(&d_->worksheets_.back());
+    return worksheet(d_->worksheets_.back());
 }
 
 worksheet workbook::copy_sheet(worksheet to_copy)
 {
     if (to_copy.d_->parent_.lock() != d_) throw invalid_parameter();
 
-    detail::worksheet_impl impl(*to_copy.d_);
+    auto impl = to_copy.d_->clone();
     auto new_sheet = create_sheet();
-    impl.title_ = new_sheet.title();
-    impl.id_ = new_sheet.id();
-    *new_sheet.d_ = impl;
+    impl->title_ = new_sheet.title();
+    impl->id_ = new_sheet.id();
+    new_sheet.d_ = impl;
+    d_->worksheets_.back() = std::move(impl);
 
     return new_sheet;
 }
@@ -859,14 +855,9 @@ worksheet workbook::copy_sheet(worksheet to_copy, std::size_t index)
 
     if (index != d_->worksheets_.size() - 1)
     {
-        auto iter = d_->worksheets_.begin();
-
-        for (std::size_t i = 0; i < index; ++i, ++iter)
-        {
-        }
-
-        d_->worksheets_.insert(iter, d_->worksheets_.back());
+        auto worksheet = std::move(d_->worksheets_.back());
         d_->worksheets_.pop_back();
+        d_->worksheets_.emplace(d_->worksheets_.begin() + index, std::move(worksheet));
     }
 
     return sheet_by_index(index);
@@ -1218,7 +1209,7 @@ void workbook::load(std::u8string_view filename, std::u8string_view password)
 void workbook::remove_sheet(worksheet ws)
 {
     auto match_iter = std::find_if(d_->worksheets_.begin(), d_->worksheets_.end(),
-        [=](detail::worksheet_impl &comp) { return &comp == ws.d_; });
+        [&ws](const auto &comp) { return comp == ws.d_; });
 
     if (match_iter == d_->worksheets_.end())
     {
@@ -1251,14 +1242,9 @@ worksheet workbook::create_sheet(std::size_t index)
 
     if (index != d_->worksheets_.size() - 1)
     {
-        auto iter = d_->worksheets_.begin();
-
-        for (std::size_t i = 0; i < index; ++i, ++iter)
-        {
-        }
-
-        d_->worksheets_.insert(iter, d_->worksheets_.back());
+        auto worksheet = std::move(d_->worksheets_.back());
         d_->worksheets_.pop_back();
+        d_->worksheets_.emplace(d_->worksheets_.begin() + index, std::move(worksheet));
     }
 
     return sheet_by_index(index);
@@ -1267,7 +1253,7 @@ worksheet workbook::create_sheet(std::size_t index)
 worksheet workbook::create_sheet_with_rel(const std::string &title, const relationship &rel)
 {
     auto sheet_id = d_->worksheets_.size() + 1;
-    d_->worksheets_.push_back(detail::worksheet_impl(this, sheet_id, title));
+    d_->worksheets_.emplace_back(std::make_shared<detail::worksheet_impl>(this, sheet_id, title));
 
     auto workbook_rel = d_->manifest_.relationship(path("/"), relationship_type::office_document);
     auto sheet_absoulute_path = workbook_rel.target().path().parent().append(rel.target().path());
@@ -1279,7 +1265,7 @@ worksheet workbook::create_sheet_with_rel(const std::string &title, const relati
 
     update_sheet_properties();
 
-    return worksheet(&d_->worksheets_.back());
+    return worksheet(d_->worksheets_.back());
 }
 
 workbook::iterator workbook::begin()
@@ -1342,7 +1328,6 @@ worksheet workbook::operator[](std::size_t index)
 void workbook::clear()
 {
     *d_ = detail::workbook_impl();
-    d_->stylesheet_.clear();
 }
 
 bool workbook::compare(const workbook &other, bool compare_by_reference) const
@@ -1378,15 +1363,14 @@ workbook workbook::clone(clone_method method) const
     {
     case clone_method::deep_copy:
     {
-        workbook wb;
-        *wb.d_ = *d_;
+        workbook wb(std::make_shared<detail::workbook_impl>(*d_));
 
         for (auto ws : wb)
         {
             ws.parent(wb);
         }
 
-        wb.d_->stylesheet_.get().parent = wb.d_;
+        wb.d_->stylesheet_->parent = wb.d_;
 
         return wb;
     }
@@ -1433,12 +1417,12 @@ std::vector<named_range> workbook::named_ranges() const
 format workbook::create_format(bool default_format)
 {
     register_workbook_part(relationship_type::stylesheet);
-    return d_->stylesheet_.get().create_format(default_format);
+    return d_->stylesheet_->create_format(default_format);
 }
 
 bool workbook::has_style(const std::string &name) const
 {
-    return d_->stylesheet_.get().has_style(name);
+    return d_->stylesheet_->has_style(name);
 }
 
 void workbook::clear_styles()
@@ -1448,27 +1432,27 @@ void workbook::clear_styles()
 
 void workbook::default_slicer_style(const std::string &value)
 {
-    d_->stylesheet_.get().default_slicer_style = value;
+    d_->stylesheet_->default_slicer_style = value;
 }
 
 std::string workbook::default_slicer_style() const
 {
-    return d_->stylesheet_.get().default_slicer_style.get();
+    return d_->stylesheet_->default_slicer_style.get();
 }
 
 void workbook::enable_known_fonts()
 {
-    d_->stylesheet_.get().known_fonts_enabled = true;
+    d_->stylesheet_->known_fonts_enabled = true;
 }
 
 void workbook::disable_known_fonts()
 {
-    d_->stylesheet_.get().known_fonts_enabled = false;
+    d_->stylesheet_->known_fonts_enabled = false;
 }
 
 bool workbook::known_fonts_enabled() const
 {
-    return d_->stylesheet_.get().known_fonts_enabled;
+    return d_->stylesheet_->known_fonts_enabled;
 }
 
 void workbook::clear_formats()
@@ -1495,12 +1479,12 @@ void workbook::apply_to_cells(std::function<void(cell)> f)
 
 format workbook::format(std::size_t format_index)
 {
-    return d_->stylesheet_.get().format(format_index);
+    return d_->stylesheet_->format(format_index);
 }
 
 const format workbook::format(std::size_t format_index) const
 {
-    return d_->stylesheet_.get().format(format_index);
+    return d_->stylesheet_->format(format_index);
 }
 
 manifest &workbook::manifest()
@@ -1592,22 +1576,22 @@ const std::unordered_map<std::string, std::vector<std::uint8_t>> &workbook::bina
 
 style workbook::create_style(const std::string &name)
 {
-    return d_->stylesheet_.get().create_style(name);
+    return d_->stylesheet_->create_style(name);
 }
 
 style workbook::create_builtin_style(const std::size_t builtin_id)
 {
-    return d_->stylesheet_.get().create_builtin_style(builtin_id);
+    return d_->stylesheet_->create_builtin_style(builtin_id);
 }
 
 style workbook::style(const std::string &name)
 {
-    return d_->stylesheet_.get().style(name);
+    return d_->stylesheet_->style(name);
 }
 
 const style workbook::style(const std::string &name) const
 {
-    return d_->stylesheet_.get().style(name);
+    return d_->stylesheet_->style(name);
 }
 
 calendar workbook::base_date() const

--- a/source/worksheet/range.cpp
+++ b/source/worksheet/range.cpp
@@ -40,8 +40,6 @@ range::range(class worksheet ws, const range_reference &reference, major_order o
 {
 }
 
-range::~range() = default;
-
 void range::clear_cells()
 {
     if (ref_.top_left().column() == ws_.lowest_column()

--- a/source/worksheet/range_iterator.cpp
+++ b/source/worksheet/range_iterator.cpp
@@ -170,7 +170,7 @@ const_range_iterator::const_range_iterator(const worksheet &ws, const cell_refer
 
 bool const_range_iterator::operator==(const const_range_iterator &other) const
 {
-    return ws_ == other.ws_
+    return ws_.lock() == other.ws_.lock()
         && cursor_ == other.cursor_
         && order_ == other.order_
         && skip_null_ == other.skip_null_;

--- a/source/worksheet/worksheet.cpp
+++ b/source/worksheet/worksheet.cpp
@@ -63,19 +63,37 @@ int points_to_pixels(double points, double dpi)
 
 namespace xlnt {
 
-worksheet::worksheet()
-    : d_(nullptr)
+worksheet::worksheet(std::shared_ptr<detail::worksheet_impl> d)
 {
+    set_impl(std::move(d));
 }
 
-worksheet::worksheet(detail::worksheet_impl *d)
-    : d_(d)
+worksheet::worksheet(std::weak_ptr<detail::worksheet_impl> d)
 {
+    set_impl(d.lock());
 }
 
-worksheet::worksheet(const worksheet &rhs)
-    : d_(rhs.d_)
+void worksheet::set_impl(std::shared_ptr<detail::worksheet_impl> impl)
 {
+    if (impl == nullptr)
+    {
+        throw xlnt::invalid_attribute("xlnt::worksheet: invalid worksheet pointer");
+    }
+
+    d_ = std::move(impl);
+}
+
+worksheet worksheet::clone(clone_method method) const
+{
+    switch (method)
+    {
+    case clone_method::deep_copy:
+        return worksheet(d_->clone());
+    case clone_method::shallow_copy:
+        return worksheet(d_);
+    default:
+        throw xlnt::invalid_parameter("clone method not supported");
+    }
 }
 
 bool worksheet::has_frozen_panes() const
@@ -205,7 +223,7 @@ void worksheet::garbage_collect()
 
     while (cell_iter != d_->cell_map_.end())
     {
-        if (xlnt::cell(&cell_iter->second).garbage_collectible())
+        if (xlnt::cell(cell_iter->second).garbage_collectible())
         {
             cell_iter = d_->cell_map_.erase(cell_iter);
         }
@@ -385,19 +403,19 @@ cell worksheet::cell(const cell_reference &reference)
     auto match = d_->cell_map_.find(reference);
     if (match == d_->cell_map_.end())
     {
-        auto impl = detail::cell_impl();
-        impl.parent_ = d_;
-        impl.column_ = reference.column_index();
-        impl.row_ = reference.row();
+        auto impl = std::make_shared<detail::cell_impl>();
+        impl->parent_ = d_;
+        impl->column_ = reference.column_index();
+        impl->row_ = reference.row();
 
-        match = d_->cell_map_.emplace(reference, impl).first;
+        match = d_->cell_map_.emplace(reference, std::move(impl)).first;
     }
-    return xlnt::cell(&match->second);
+    return xlnt::cell(match->second);
 }
 
 const cell worksheet::cell(const cell_reference &reference) const
 {
-    return xlnt::cell(&d_->cell_map_.at(reference));
+    return xlnt::cell(d_->cell_map_.at(reference));
 }
 
 cell worksheet::cell(xlnt::column_t column, row_t row)
@@ -616,11 +634,11 @@ range_reference worksheet::calculate_dimension(bool skip_null, bool skip_row_pro
     for (auto &c : d_->cell_map_)
     {
         if(skip_null){
-            min_col = std::min(min_col, c.second.column_);
-            min_row = std::min(min_row, c.second.row_);
+            min_col = std::min(min_col, c.second->column_);
+            min_row = std::min(min_row, c.second->row_);
         }
-        max_col = std::max(max_col, c.second.column_);
-        max_row = std::max(max_row, c.second.row_);
+        max_col = std::max(max_col, c.second->column_);
+        max_row = std::max(max_row, c.second->row_);
     }
     return range_reference(min_col, min_row, max_col, max_row);
 }
@@ -816,7 +834,7 @@ void worksheet::move_cells(std::uint32_t min_index, std::uint32_t amount, row_or
         throw xlnt::exception("Cannot move cells as they would be outside the maximum bounds of the spreadsheet");
     }
 
-    std::vector<detail::cell_impl> cells_to_move;
+    std::vector<std::shared_ptr<detail::cell_impl>> cells_to_move;
 
     auto cell_iter = d_->cell_map_.cbegin();
     while (cell_iter != d_->cell_map_.cend())
@@ -839,14 +857,14 @@ void worksheet::move_cells(std::uint32_t min_index, std::uint32_t amount, row_or
             auto cell = cell_iter->second;
             if (row_or_col == row_or_col_t::row)
             {
-                cell.row_ = reverse ? cell.row_ - amount : cell.row_ + amount;
+                cell->row_ = reverse ? cell->row_ - amount : cell->row_ + amount;
             }
             else if (row_or_col == row_or_col_t::column)
             {
-                cell.column_ = reverse ? cell.column_.index - amount : cell.column_.index + amount;
+                cell->column_ = reverse ? cell->column_.index - amount : cell->column_.index + amount;
             }
 
-            cells_to_move.push_back(cell);
+            cells_to_move.emplace_back(std::move(cell));
             cell_iter = d_->cell_map_.erase(cell_iter);
         }
         else if (reverse && current_index >= min_index - amount) // delete destination cells
@@ -861,7 +879,7 @@ void worksheet::move_cells(std::uint32_t min_index, std::uint32_t amount, row_or
 
     for (auto &cell : cells_to_move)
     {
-        d_->cell_map_[cell_reference(cell.column_, cell.row_)] = cell;
+        d_->cell_map_[cell_reference(cell->column_, cell->row_)] = std::move(cell);
     }
 
     if (row_or_col == row_or_col_t::row)
@@ -986,11 +1004,6 @@ bool worksheet::operator==(std::nullptr_t) const
 bool worksheet::operator!=(std::nullptr_t) const
 {
     return d_ != nullptr;
-}
-
-void worksheet::operator=(const worksheet &other)
-{
-    d_ = other.d_;
 }
 
 const cell worksheet::operator[](const cell_reference &ref) const
@@ -1286,7 +1299,7 @@ void worksheet::parent(xlnt::workbook &wb)
 
 conditional_format worksheet::conditional_format(const range_reference &ref, const condition &when)
 {
-    return workbook().d_->stylesheet_.get().add_conditional_format_rule(d_, ref, when);
+    return workbook().d_->stylesheet_->add_conditional_format_rule(d_, ref, when);
 }
 
 path worksheet::path() const

--- a/tests/cell/hyperlink_test_suite.cpp
+++ b/tests/cell/hyperlink_test_suite.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2024-2025 xlnt-community
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE
+//
+// @license: http://www.opensource.org/licenses/mit-license.php
+// @author: see AUTHORS file
+
+#include <xlnt/cell/hyperlink.hpp>
+#include <helpers/test_suite.hpp>
+#include <xlnt/xlnt.hpp>
+
+class hyperlink_test_suite : public test_suite
+{
+public:
+    hyperlink_test_suite()
+    {
+        register_test(test_clone);
+        register_test(test_compare);
+    }
+
+    void test_clone()
+    {
+        xlnt::workbook wb;
+        xlnt::worksheet ws = wb.active_sheet();
+        xlnt::cell cell11 = ws.cell(1, 1);
+        cell11.hyperlink("https://www.example.com");
+        xlnt::hyperlink hyperlink = cell11.hyperlink();
+        hyperlink.tooltip("https://www.example.com");
+        xlnt::hyperlink hyperlink_simple_copy = hyperlink;
+        hyperlink.tooltip("https://www.example.org");
+        xlnt_assert_equals(hyperlink_simple_copy.tooltip(), "https://www.example.org");
+        xlnt::hyperlink hyperlink_shallow_copy = hyperlink.clone(xlnt::clone_method::shallow_copy);
+        hyperlink.tooltip("https://www.example.net");
+        xlnt_assert_equals(hyperlink_shallow_copy.tooltip(), "https://www.example.net");
+        xlnt::hyperlink hyperlink_deep_copy = hyperlink.clone(xlnt::clone_method::deep_copy);
+        hyperlink.tooltip("https://www.example");
+        xlnt_assert_equals(hyperlink_deep_copy.tooltip(), "https://www.example.net");
+    }
+
+    void test_compare()
+    {
+        xlnt::workbook wb;
+        xlnt::worksheet ws = wb.active_sheet();
+        xlnt::cell cell11 = ws.cell(1, 1);
+        cell11.hyperlink("https://www.example.com");
+        xlnt::hyperlink hyperlink = cell11.hyperlink();
+        xlnt::hyperlink hyperlink_simple_copy = hyperlink;
+        xlnt_assert_equals(hyperlink, hyperlink_simple_copy);
+        xlnt_assert(hyperlink.compare(hyperlink_simple_copy, true));
+        xlnt_assert(hyperlink.compare(hyperlink_simple_copy, false));
+        xlnt::hyperlink hyperlink_shallow_copy = hyperlink.clone(xlnt::clone_method::shallow_copy);
+        xlnt_assert_equals(hyperlink, hyperlink_shallow_copy);
+        xlnt_assert(hyperlink.compare(hyperlink_shallow_copy, true));
+        xlnt_assert(hyperlink.compare(hyperlink_shallow_copy, false));
+        xlnt::hyperlink hyperlink_deep_copy = hyperlink.clone(xlnt::clone_method::deep_copy);
+        xlnt_assert_differs(hyperlink, hyperlink_deep_copy);
+        xlnt_assert(!hyperlink.compare(hyperlink_deep_copy, true));
+        xlnt_assert(hyperlink.compare(hyperlink_deep_copy, false));
+    }
+};
+
+static hyperlink_test_suite x;

--- a/tests/styles/format_test_suite.cpp
+++ b/tests/styles/format_test_suite.cpp
@@ -1,4 +1,3 @@
-// Copyright (c) 2014-2022 Thomas Fussell
 // Copyright (c) 2024-2025 xlnt-community
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,61 +21,31 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 
-#include <xlnt/styles/conditional_format.hpp>
+#include <xlnt/styles/format.hpp>
 #include <helpers/test_suite.hpp>
 #include <xlnt/xlnt.hpp>
 
-class conditional_format_test_suite : public test_suite
+class format_test_suite : public test_suite
 {
 public:
-    conditional_format_test_suite()
+    format_test_suite()
     {
-        register_test(test_all);
         register_test(test_clone);
         register_test(test_compare);
-    }
-
-    void test_all()
-    {
-        xlnt::workbook wb;
-        auto ws = wb.active_sheet();
-        auto format = ws.conditional_format(xlnt::range_reference("A1:A10"), xlnt::condition::text_contains("test"));
-        xlnt_assert(!format.has_border());
-        xlnt_assert(!format.has_fill());
-        xlnt_assert(!format.has_font());
-        // set border
-        auto border = xlnt::border().diagonal(xlnt::diagonal_direction::both);
-        format.border(border);
-        xlnt_assert(format.has_border());
-        xlnt_assert_equals(format.border(), border);
-        // set fill
-        auto fill = xlnt::fill(xlnt::gradient_fill().type(xlnt::gradient_fill_type::path));
-        format.fill(fill);
-        xlnt_assert(format.has_fill());
-        xlnt_assert_equals(format.fill(), fill);
-        // set font
-        auto font = xlnt::font().color(xlnt::color::darkblue());
-        format.font(font);
-        xlnt_assert(format.has_font());
-        xlnt_assert_equals(format.font(), font);
-        // copy ctor
-        auto format_copy(format);
-        xlnt_assert_equals(format, format_copy);
     }
 
     void test_clone()
     {
         xlnt::workbook wb;
-        xlnt::worksheet ws = wb.active_sheet();
-        xlnt::conditional_format format = ws.conditional_format(xlnt::range_reference("A1:A10"), xlnt::condition::text_contains("test"));
+        xlnt::format format = wb.create_format("test_format");
         format.border(xlnt::border().side(xlnt::border_side::bottom, xlnt::border::border_property().color(xlnt::color::red())));
-        xlnt::conditional_format format_simple_copy = format;
+        xlnt::format format_simple_copy = format;
         format.border(xlnt::border().side(xlnt::border_side::bottom, xlnt::border::border_property().color(xlnt::color::green())));
         xlnt_assert_equals(format_simple_copy.border().side(xlnt::border_side::bottom).get().color().get(), xlnt::color::green());
-        xlnt::conditional_format format_shallow_copy = format.clone(xlnt::clone_method::shallow_copy);
+        xlnt::format format_shallow_copy = format.clone(xlnt::clone_method::shallow_copy);
         format.border(xlnt::border().side(xlnt::border_side::bottom, xlnt::border::border_property().color(xlnt::color::blue())));
         xlnt_assert_equals(format_shallow_copy.border().side(xlnt::border_side::bottom).get().color().get(), xlnt::color::blue());
-        xlnt::conditional_format format_deep_copy = format.clone(xlnt::clone_method::deep_copy);
+        xlnt::format format_deep_copy = format.clone(xlnt::clone_method::deep_copy);
         format.border(xlnt::border().side(xlnt::border_side::bottom, xlnt::border::border_property().color(xlnt::color::darkred())));
         xlnt_assert_equals(format_deep_copy.border().side(xlnt::border_side::bottom).get().color().get(), xlnt::color::blue());
     }
@@ -84,20 +53,20 @@ public:
     void test_compare()
     {
         xlnt::workbook wb;
-        xlnt::worksheet ws = wb.active_sheet();
-        xlnt::conditional_format format = ws.conditional_format(xlnt::range_reference("A1:A10"), xlnt::condition::text_contains("test"));
-        xlnt::conditional_format format_simple_copy = format;
+        xlnt::format format = wb.create_format("test_format");
+        xlnt::format format_simple_copy = format;
         xlnt_assert_equals(format, format_simple_copy);
         xlnt_assert(format.compare(format_simple_copy, true));
         xlnt_assert(format.compare(format_simple_copy, false));
-        xlnt::conditional_format format_shallow_copy = format.clone(xlnt::clone_method::shallow_copy);
+        xlnt::format format_shallow_copy = format.clone(xlnt::clone_method::shallow_copy);
         xlnt_assert_equals(format, format_shallow_copy);
         xlnt_assert(format.compare(format_shallow_copy, true));
         xlnt_assert(format.compare(format_shallow_copy, false));
-        xlnt::conditional_format format_deep_copy = format.clone(xlnt::clone_method::deep_copy);
+        xlnt::format format_deep_copy = format.clone(xlnt::clone_method::deep_copy);
         xlnt_assert_differs(format, format_deep_copy);
         xlnt_assert(!format.compare(format_deep_copy, true));
         xlnt_assert(format.compare(format_deep_copy, false));
     }
 };
-static conditional_format_test_suite x;
+
+static format_test_suite x;

--- a/tests/styles/style_test_suite.cpp
+++ b/tests/styles/style_test_suite.cpp
@@ -32,6 +32,8 @@ public:
     style_test_suite()
     {
         register_test(test_all);
+        register_test(test_clone);
+        register_test(test_compare);
     }
 
     void test_all()
@@ -61,6 +63,40 @@ public:
         xlnt_assert(!copy_style.quote_prefix());
         copy_style.quote_prefix(true);
         xlnt_assert(copy_style.quote_prefix());
+    }
+
+    void test_clone()
+    {
+        xlnt::workbook wb;
+        xlnt::style style = wb.create_style("test_style");
+        style.border(xlnt::border().side(xlnt::border_side::bottom, xlnt::border::border_property().color(xlnt::color::red())));
+        xlnt::style style_simple_copy = style;
+        style.border(xlnt::border().side(xlnt::border_side::bottom, xlnt::border::border_property().color(xlnt::color::green())));
+        xlnt_assert_equals(style_simple_copy.border().side(xlnt::border_side::bottom).get().color().get(), xlnt::color::green());
+        xlnt::style style_shallow_copy = style.clone(xlnt::clone_method::shallow_copy);
+        style.border(xlnt::border().side(xlnt::border_side::bottom, xlnt::border::border_property().color(xlnt::color::blue())));
+        xlnt_assert_equals(style_shallow_copy.border().side(xlnt::border_side::bottom).get().color().get(), xlnt::color::blue());
+        xlnt::style style_deep_copy = style.clone(xlnt::clone_method::deep_copy);
+        style.border(xlnt::border().side(xlnt::border_side::bottom, xlnt::border::border_property().color(xlnt::color::darkred())));
+        xlnt_assert_equals(style_deep_copy.border().side(xlnt::border_side::bottom).get().color().get(), xlnt::color::blue());
+    }
+
+    void test_compare()
+    {
+        xlnt::workbook wb;
+        xlnt::style style = wb.create_style("test_style");
+        xlnt::style style_simple_copy = style;
+        xlnt_assert_equals(style, style_simple_copy);
+        xlnt_assert(style.compare(style_simple_copy, true));
+        xlnt_assert(style.compare(style_simple_copy, false));
+        xlnt::style style_shallow_copy = style.clone(xlnt::clone_method::shallow_copy);
+        xlnt_assert_equals(style, style_shallow_copy);
+        xlnt_assert(style.compare(style_shallow_copy, true));
+        xlnt_assert(style.compare(style_shallow_copy, false));
+        xlnt::style style_deep_copy = style.clone(xlnt::clone_method::deep_copy);
+        xlnt_assert_differs(style, style_deep_copy);
+        xlnt_assert(!style.compare(style_deep_copy, true));
+        xlnt_assert(style.compare(style_deep_copy, false));
     }
 };
 static style_test_suite x;

--- a/tests/workbook/workbook_test_suite.cpp
+++ b/tests/workbook/workbook_test_suite.cpp
@@ -74,6 +74,7 @@ public:
         register_test(test_id_gen);
         register_test(test_load_file);
         register_test(test_load_file_encrypted);
+        register_test(test_ensure_correct_lifetime);
         register_test(test_Issue279);
         register_test(test_Issue353);
         register_test(test_Issue494);
@@ -583,6 +584,21 @@ public:
         xlnt::workbook wb_load5;
         wb_load5.load(data, password);
         xlnt_assert(wb_path.compare(wb_load5, false));
+    }
+
+    void test_ensure_correct_lifetime()
+    {
+        // Use a pointer to extend the lifetime outside the scope below.
+        std::unique_ptr<xlnt::workbook> workbook;
+
+        {
+            xlnt::workbook wb;
+            wb.title("Title1");
+            // Create a shallow copy.
+            workbook = std::unique_ptr<xlnt::workbook>(new xlnt::workbook(wb));
+        }
+
+        xlnt_assert_equals(workbook->title(), "Title1");
     }
 
     void test_Issue279()

--- a/tests/worksheet/worksheet_test_suite.cpp
+++ b/tests/worksheet/worksheet_test_suite.cpp
@@ -30,6 +30,7 @@
 #include <xlnt/worksheet/range.hpp>
 #include <xlnt/worksheet/row_properties.hpp>
 #include <xlnt/worksheet/worksheet.hpp>
+#include <xlnt/types.hpp>
 #include <helpers/test_suite.hpp>
 
 class worksheet_test_suite : public test_suite
@@ -110,6 +111,9 @@ public:
         register_test(test_insert_too_many);
         register_test(test_insert_delete_moves_merges);
         register_test(test_hidden_sheet);
+        register_test(test_ensure_correct_lifetime);
+        register_test(test_clone);
+        register_test(test_compare);
         register_test(test_xlsm_read_write);
         register_test(test_issue_484);
         register_test(test_issue_5_empty_bottom_rows);
@@ -1613,6 +1617,59 @@ public:
         xlnt::workbook wb;
         wb.load(path_helper::test_file("16_hidden_sheet.xlsx"));
         xlnt_assert_equals(wb.sheet_hidden_by_index(1), true);
+    }
+
+    void test_ensure_correct_lifetime()
+    {
+        // Use a pointer to extend the lifetime outside the scope below.
+        std::unique_ptr<xlnt::worksheet> worksheet;
+
+        {
+            xlnt::workbook wb;
+            xlnt::worksheet ws = wb.create_sheet();
+            ws.title("Title1");
+            // Create a shallow copy.
+            worksheet = std::unique_ptr<xlnt::worksheet>(new xlnt::worksheet(ws));
+            xlnt_assert_throws_nothing(ws.workbook());
+        }
+
+        xlnt_assert_equals(worksheet->title(), "Title1");
+        xlnt_assert_throws(worksheet->workbook(), xlnt::invalid_attribute);
+    }
+
+    void test_clone()
+    {
+        xlnt::workbook wb;
+        xlnt::worksheet ws = wb.active_sheet();
+        ws.title("NEW1");
+        xlnt::worksheet ws_simple_copy = ws;
+        xlnt_assert_equals(ws.title(), "NEW1");
+        xlnt::worksheet ws_shallow_copy = ws.clone(xlnt::clone_method::shallow_copy);
+        xlnt_assert_equals(ws_shallow_copy.title(), "NEW1");
+        ws.title("NEW2");
+        xlnt_assert_equals(ws_shallow_copy.title(), "NEW2");
+        xlnt::worksheet ws_deep_copy = ws.clone(xlnt::clone_method::deep_copy);
+        ws.title("NEW3");
+        xlnt_assert_equals(ws_deep_copy.title(), "NEW2");
+    }
+
+    void test_compare()
+    {
+        xlnt::workbook wb;
+        xlnt::worksheet ws = wb.active_sheet();
+        ws.title("NEW1");
+        xlnt::worksheet ws_simple_copy = ws;
+        xlnt_assert_equals(ws, ws_simple_copy);
+        xlnt_assert(ws.compare(ws_simple_copy, true));
+        xlnt_assert(ws.compare(ws_simple_copy, false));
+        xlnt::worksheet ws_shallow_copy = ws.clone(xlnt::clone_method::shallow_copy);
+        xlnt_assert_equals(ws, ws_shallow_copy);
+        xlnt_assert(ws.compare(ws_shallow_copy, true));
+        xlnt_assert(ws.compare(ws_shallow_copy, false));
+        xlnt::worksheet ws_deep_copy = ws.clone(xlnt::clone_method::deep_copy);
+        xlnt_assert_differs(ws, ws_deep_copy);
+        xlnt_assert(!ws.compare(ws_deep_copy, true));
+        xlnt_assert(ws.compare(ws_deep_copy, false));
     }
 
     void test_xlsm_read_write()


### PR DESCRIPTION
As previously discussed in PR https://github.com/xlnt-community/xlnt/pull/59, this PR improves XLNT memory safety even if the objects they belong to no longer exist. This helps with use cases where caching certain cells, worksheets or styles is necessary, now preventing use-after-free errors.