### PR TITLE
Removed message in documentation regarding outdated vcpkg port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](http://opensource.org/licenses/MIT)
 
 ## Introduction
-xlnt is a modern C++ library (requiring c++11 or above) for manipulating spreadsheets in memory and reading/writing them from/to XLSX files as described in [ECMA 376 5th edition](https://ecma-international.org/publications-and-standards/standards/ecma-376/). The first public release of xlnt version 1.0 was on May 10th, 2017. Current work is focused on increasing compatibility, improving performance, and brainstorming future development goals. For a high-level summary of what you can do with this library, see [the feature list](https://xlnt-community.gitbook.io/xlnt/introduction/features). Contributions are welcome in the form of pull requests or discussions on [the repository's Issues page](https://github.com/xlnt-community/xlnt/issues).
+xlnt is a modern C++ library (requiring c++11 or above) for manipulating spreadsheets in memory and reading/writing them from/to XLSX (Microsoft Excel®) files as described in [ECMA 376 5th edition](https://ecma-international.org/publications-and-standards/standards/ecma-376/). The first public release of xlnt version 1.0 was on May 10th, 2017. Current work is focused on increasing compatibility, improving performance, and brainstorming future development goals. For a high-level summary of what you can do with this library, see [the feature list](https://xlnt-community.gitbook.io/xlnt/introduction/features). Contributions are welcome in the form of pull requests or discussions on [the repository's Issues page](https://github.com/xlnt-community/xlnt/issues).
 
 ## About this fork
 This repo is a community effort to continue the development of xlnt, after the [original repo of tfussel](https://github.com/tfussell/xlnt) has been unmaintained for many years (see [Issue #748](https://github.com/tfussell/xlnt/issues/748)).
@@ -60,10 +60,6 @@ For more information, see the [full installation instructions](https://xlnt-comm
 
 ## Building xlnt - Using vcpkg
 
-> [!WARNING]
-> The xlnt port in vcpkg is currently out of date, as it still uses the original repo of tfussell. We are in the process of migrating this port to our community edition (see [Issue #33](https://github.com/xlnt-community/xlnt/issues/33) for more information).
-> At this time, we recommend building xlnt from source.
-
 You can download and install xlnt using the [vcpkg](https://github.com/microsoft/vcpkg) dependency manager:
 
     git clone https://github.com/microsoft/vcpkg.git
@@ -72,7 +68,7 @@ You can download and install xlnt using the [vcpkg](https://github.com/microsoft
     ./vcpkg integrate install
     ./vcpkg install xlnt
 
-The xlnt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/microsoft/vcpkg) on the vcpkg repository.
+The [xlnt port in vcpkg](https://vcpkg.io/en/package/xlnt) is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/microsoft/vcpkg) on the vcpkg repository.
 
 ## License
 xlnt is released to the public for free under the terms of the MIT License. See [LICENSE.md](https://github.com/xlnt-community/xlnt/blob/master/LICENSE.md) for the full text of the license and the licenses of xlnt's third-party dependencies. [LICENSE.md](https://github.com/xlnt-community/xlnt/blob/master/LICENSE.md) should be distributed alongside any assemblies that use xlnt in source or compiled form.

--- a/docs/introduction/Installation.md
+++ b/docs/introduction/Installation.md
@@ -1,10 +1,13 @@
 # Getting xlnt
 
+The most up to date and stable version can be obtained by building xlnt from source (using the master branch).
+
 ## Binaries
 
-Provided binaries (v1.5.0) are rather old, it may be better to build from source at least until new binaries are available.
-
 ### Arch
+
+> [!WARNING]
+> Provided binary (v1.5.0) is rather old, it may be better to build from source or use vcpkg.
 
 xlnt can be [found](https://aur.archlinux.org/packages/xlnt/) on the AUR.
 


### PR DESCRIPTION
Related to #33 