### PR TITLE
const qualifier added to 'index(worksheet worksheet)'

### DIFF
--- a/include/xlnt/workbook/workbook.hpp
+++ b/include/xlnt/workbook/workbook.hpp
@@ -297,7 +297,7 @@ public:
     /// <summary>
     /// Returns the index of the given worksheet. The worksheet must be owned by this workbook.
     /// </summary>
-    std::size_t index(worksheet worksheet);
+    std::size_t index(worksheet worksheet) const;
 
     // remove worksheets
 

--- a/source/workbook/workbook.cpp
+++ b/source/workbook/workbook.cpp
@@ -872,7 +872,7 @@ worksheet workbook::copy_sheet(worksheet to_copy, std::size_t index)
     return sheet_by_index(index);
 }
 
-std::size_t workbook::index(worksheet ws)
+std::size_t workbook::index(worksheet ws) const
 {
     auto match = std::find(begin(), end(), ws);
 


### PR DESCRIPTION
I added const quilifier to  'workbook::index(worksheet worksheet)' function to be able to identify worksheet index using 
xlnt::worksheet::workbook().index(xlnt::worksheet)