### PR TITLE
Publishing coverage to github pages

### DIFF
--- a/.circleci/config_pr.yml
+++ b/.circleci/config_pr.yml
@@ -1,0 +1,15 @@
+version: 2.1
+
+jobs:
+  post-coverage-comment:
+    docker:
+      - image: cimg/base:current
+    resource_class: small
+    steps:
+      - checkout
+      - run: .circleci/post_coverage_comment.sh <<pipeline.event.github.pull_request.number>>
+
+workflows:
+  new-pr:
+    jobs:
+      - post-coverage-comment

--- a/.circleci/continue_config_in.yml
+++ b/.circleci/continue_config_in.yml
@@ -21,6 +21,9 @@ jobs:
       benchmarks:
         default: "OFF"
         type: string
+      benchmark-run-count:
+        default: 10
+        type: integer
       micro-benchmarks:
         default: "OFF"
         type: string
@@ -71,7 +74,7 @@ jobs:
           steps:
             - run: ./benchmarks/benchmark-styles
             - run: ./benchmarks/benchmark-writer
-            - run: ./benchmarks/benchmark-spreadsheet-load
+            - run: ./benchmarks/benchmark-spreadsheet-load << parameters.benchmark-run-count >>
       - when:
           condition:
             equal: ["ON", << parameters.micro-benchmarks >>]
@@ -82,10 +85,36 @@ jobs:
             equal: ["ON", << parameters.coverage >>]
           steps:
             - run: apt-get update -y
-            - run: apt-get install -y --no-install-recommends lcov
-            - run: lcov --directory . --capture --output-file coverage.info --base-directory . --no-external
-            - run: lcov --extract coverage.info "$PWD/include/*" "$PWD/source/*" --output-file coverage.info
+            - run: apt-get install -y --no-install-recommends perl libcapture-tiny-perl libdatetime-perl libtimedate-perl libjson-perl libperlio-gzip-perl libjson-xs-perl
+            - run: git clone https://github.com/linux-test-project/lcov.git --depth 1 --branch v2.3.1
+            - run: cd lcov && make -j2 install
+            - run: lcov --directory . --capture --output-file coverage.info --base-directory . --no-external --include "$PWD/include/*" --include "$PWD/source/*" --branch-coverage --rc no_exception_branch=1 -j 2
             - run: curl -sL https://coveralls.io/coveralls-linux.tar.gz | tar -xz && ./coveralls report coverage.info
+            - run: curl -sL https://raw.githubusercontent.com/xlnt-community/xlnt-coverage/refs/heads/gh-pages/`git rev-parse master`/coverage.info > coverage_master.info
+            - run: lcov/scripts/gitdiff -b . master HEAD > diff.txt
+            - run: genhtml -j 2 -p $PWD --output-directory coverage/differential --baseline-file coverage_master.info --diff-file diff.txt --branch-coverage --ignore-errors inconsistent --header-title "differential code coverage report with master" -- coverage.info
+            - run: genhtml -j 2 -p $PWD --output-directory coverage/review --baseline-file coverage_master.info --diff-file diff.txt --branch-coverage --ignore-errors inconsistent --header-title "review summary" --flat --select-script lcov/scripts/select.pm --select-script --tla --select-script UNC,UIC,LBC -- coverage.info
+            - run: mv coverage.info coverage/
+            - persist_to_workspace:
+                root: .
+                paths: coverage
+
+  coverage-deploy:
+    docker:
+      - image: node:8.10.0
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: npm install -g --silent gh-pages@2.0.1
+      - run: git config user.email "<>"
+      - run: git config user.name "circleci"
+      - add_ssh_keys:
+          fingerprints:
+            - "SHA256:VmE7CvosRKmkFPk2phSGqDr412LRvV1i4t9Oequ6KuI"
+      - run: gh-pages --message "Update coverage" --dist coverage --dest `git rev-parse HEAD` --repo git@github.com:xlnt-community/xlnt-coverage.git
+      - run: .circleci/post_coverage_comment.sh
 
   docs-build:
     docker:
@@ -357,6 +386,14 @@ workflows:
           samples: "ON"
           benchmarks: "ON"
           coverage: "ON"
+          benchmark-run-count: 1
+          filters:
+            branches:
+              ignore: gh-pages
+
+      - coverage-deploy:
+          requires:
+            - samples-benchmarks-coverage-gcc
           filters:
             branches:
               ignore: gh-pages

--- a/.circleci/continue_config_in.yml
+++ b/.circleci/continue_config_in.yml
@@ -377,23 +377,18 @@ workflows:
     when: HAS_COVERALLS
     jobs:
       - build-gcc:
-          name: samples-benchmarks-coverage-gcc
+          name: coverage-gcc
           image: PLACEHOLDER_IMAGE(gcc_cmake_latest)
           cxx-ver: "23"
-          warnings-as-errors: "ON"
           build-type: Debug
-          static: "ON"
-          samples: "ON"
-          benchmarks: "ON"
           coverage: "ON"
-          benchmark-run-count: 1
           filters:
             branches:
               ignore: gh-pages
 
       - coverage-deploy:
           requires:
-            - samples-benchmarks-coverage-gcc
+            - coverage-gcc
           filters:
             branches:
               ignore: gh-pages

--- a/.circleci/continue_config_in.yml
+++ b/.circleci/continue_config_in.yml
@@ -21,9 +21,6 @@ jobs:
       benchmarks:
         default: "OFF"
         type: string
-      benchmark-run-count:
-        default: 10
-        type: integer
       micro-benchmarks:
         default: "OFF"
         type: string
@@ -74,7 +71,7 @@ jobs:
           steps:
             - run: ./benchmarks/benchmark-styles
             - run: ./benchmarks/benchmark-writer
-            - run: ./benchmarks/benchmark-spreadsheet-load << parameters.benchmark-run-count >>
+            - run: ./benchmarks/benchmark-spreadsheet-load
       - when:
           condition:
             equal: ["ON", << parameters.micro-benchmarks >>]

--- a/.circleci/post_coverage_comment.sh
+++ b/.circleci/post_coverage_comment.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eo pipefail
+
+PR_NUMBER_OVERIDE=$1
+
+post_coverage_comment ()
+{
+  PR_NUMBER=$1
+  COMMIT_SHA=$2
+
+  echo "Posting comment at PR $PR_NUMBER"
+
+  curl -L -X POST \
+    -H "Authorization: Bearer ${PR_TOKEN}" \
+    "https://api.github.com/repos/xlnt-community/xlnt/issues/${PR_NUMBER}/comments" \
+    -d "{\"body\":\"Coverage report is available at: [full](https://xlnt-community.github.io/xlnt-coverage/${COMMIT_SHA}/differential/index.html) | [review summary](https://xlnt-community.github.io/xlnt-coverage/${COMMIT_SHA}/review/index.html)\"}"
+}
+
+main ()
+{
+  COMMIT_SHA=`git rev-parse HEAD`
+
+  if [ -n "${PR_NUMBER_OVERIDE}" ]; then
+    post_coverage_comment ${PR_NUMBER_OVERIDE} ${COMMIT_SHA}
+  elif [ -n "${CIRCLE_PR_NUMBER}" ]; then
+    post_coverage_comment ${CIRCLE_PR_NUMBER} ${COMMIT_SHA}
+  elif [[ $"${CIRCLE_PULL_REQUEST}" =~ https://github.com/xlnt-community/xlnt/pull/([0-9]+)$ ]]; then
+    post_coverage_comment ${BASH_REMATCH[1]} ${COMMIT_SHA}
+  elif [[ $"${CIRCLE_BRANCH}" =~ pull/([0-9]+)(/.*)?$ ]]; then
+    post_coverage_comment ${BASH_REMATCH[1]} ${COMMIT_SHA}
+  else
+    echo "not associated with a PR"
+  fi
+}
+
+main
+

--- a/.circleci/post_coverage_comment.sh
+++ b/.circleci/post_coverage_comment.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-PR_NUMBER_OVERIDE=$1
+PR_NUMBER_OVERRIDE=$1
 
 post_coverage_comment ()
 {
@@ -21,8 +21,8 @@ main ()
 {
   COMMIT_SHA=`git rev-parse HEAD`
 
-  if [ -n "${PR_NUMBER_OVERIDE}" ]; then
-    post_coverage_comment ${PR_NUMBER_OVERIDE} ${COMMIT_SHA}
+  if [ -n "${PR_NUMBER_OVERRIDE}" ]; then
+    post_coverage_comment ${PR_NUMBER_OVERRIDE} ${COMMIT_SHA}
   elif [ -n "${CIRCLE_PR_NUMBER}" ]; then
     post_coverage_comment ${CIRCLE_PR_NUMBER} ${COMMIT_SHA}
   elif [[ $"${CIRCLE_PULL_REQUEST}" =~ https://github.com/xlnt-community/xlnt/pull/([0-9]+)$ ]]; then

--- a/benchmarks/spreadsheet-load.cpp
+++ b/benchmarks/spreadsheet-load.cpp
@@ -48,15 +48,11 @@ void run_save_test(const xlnt::path &file, int runs = 10)
 }
 } // namespace
 
-int main(int argc, char * argv[])
+int main()
 {
-    int runs = 10;
-    if (argc > 1)
-        runs = std::stoi(argv[1]);
+    run_load_test(path_helper::benchmark_file("large.xlsx"));
+    run_load_test(path_helper::benchmark_file("very_large.xlsx"));
 
-    run_load_test(path_helper::benchmark_file("large.xlsx"), runs);
-    run_load_test(path_helper::benchmark_file("very_large.xlsx"), runs);
-
-    run_save_test(path_helper::benchmark_file("large.xlsx"), runs);
-    run_save_test(path_helper::benchmark_file("very_large.xlsx"), runs);
+    run_save_test(path_helper::benchmark_file("large.xlsx"));
+    run_save_test(path_helper::benchmark_file("very_large.xlsx"));
 }

--- a/benchmarks/spreadsheet-load.cpp
+++ b/benchmarks/spreadsheet-load.cpp
@@ -48,11 +48,15 @@ void run_save_test(const xlnt::path &file, int runs = 10)
 }
 } // namespace
 
-int main()
+int main(int argc, char * argv[])
 {
-    run_load_test(path_helper::benchmark_file("large.xlsx"));
-    run_load_test(path_helper::benchmark_file("very_large.xlsx"));
+    int runs = 10;
+    if (argc > 1)
+        runs = std::stoi(argv[1]);
 
-    run_save_test(path_helper::benchmark_file("large.xlsx"));
-    run_save_test(path_helper::benchmark_file("very_large.xlsx"));
+    run_load_test(path_helper::benchmark_file("large.xlsx"), runs);
+    run_load_test(path_helper::benchmark_file("very_large.xlsx"), runs);
+
+    run_save_test(path_helper::benchmark_file("large.xlsx"), runs);
+    run_save_test(path_helper::benchmark_file("very_large.xlsx"), runs);
 }

--- a/source/utils/variant.cpp
+++ b/source/utils/variant.cpp
@@ -71,7 +71,7 @@ void variant::construct_vector_internal(const T &vec)
     }
 }
 
-variant::variant(const std::initializer_list<int> &value)
+variant::variant(const std::initializer_list<std::int32_t> &value)
     : type_(type::vector)
 {
     construct_vector_internal(value);

--- a/tests/cell/index_types_test_suite.cpp
+++ b/tests/cell/index_types_test_suite.cpp
@@ -35,6 +35,7 @@ public:
         register_test(test_bad_string_numbers);
         register_test(test_bad_index_zero);
         register_test(test_column_operators);
+        register_test(test_column_z);
     }
 
     void test_bad_string_empty()
@@ -98,6 +99,11 @@ public:
         xlnt_assert(!(3 >= c2));
         xlnt_assert(3 <= c1);
         xlnt_assert(!(4 <= c1));
+    }
+
+    void test_column_z()
+    {
+        xlnt_assert_equals(xlnt::column_t::column_string_from_index(26), "Z");
     }
 };
 

--- a/tests/utils/variant_tests.cpp
+++ b/tests/utils/variant_tests.cpp
@@ -56,13 +56,23 @@ public:
 
     void test_int32_vector()
     {
-        std::vector<std::int32_t> vec {10, 20, 30, 40};
+        test_vector({10, 20, 30, 40, std::numeric_limits<std::int32_t>::min(), std::numeric_limits<std::int32_t>::max()});
+    }
+
+    template<typename T>
+    void test_vector(const std::initializer_list<T>& list)
+    {
+        std::vector<T> vec(list);
         xlnt::variant var_int_vec(vec);
         xlnt_assert_equals(var_int_vec.value_type(), xlnt::variant::type::vector);
         xlnt_assert(var_int_vec.is(xlnt::variant::type::vector));
-        std::vector<std::int32_t> vec_returned;
-        xlnt_assert_throws_nothing(vec_returned = var_int_vec.get<std::vector<std::int32_t>>());
+        std::vector<T> vec_returned;
+        xlnt_assert_throws_nothing(vec_returned = var_int_vec.get<std::vector<T>>());
         xlnt_assert_equals(vec, vec_returned);
+
+        xlnt::variant var_int_list(list);
+        xlnt_assert_equals(var_int_list, var_int_vec);
+        xlnt_assert_equals(var_int_list.get<std::vector<T>>(), vec);
     }
 
     void test_string()
@@ -82,13 +92,7 @@ public:
 
     void test_string_vector()
     {
-        std::vector<std::string> vec {"test1", "test2", "test3", "test4"};
-        xlnt::variant var_str1_vec(vec);
-        xlnt_assert_equals(var_str1_vec.value_type(), xlnt::variant::type::vector);
-        xlnt_assert(var_str1_vec.is(xlnt::variant::type::vector));
-        std::vector<std::string> vec_returned;
-        xlnt_assert_throws_nothing(vec_returned = var_str1_vec.get<std::vector<std::string>>());
-        xlnt_assert_equals(vec, vec_returned);
+        test_vector<std::string>({"test1", "test2", "test3", "test4"});
     }
 };
 static variant_test_suite x;

--- a/tests/workbook/workbook_test_suite.cpp
+++ b/tests/workbook/workbook_test_suite.cpp
@@ -77,6 +77,7 @@ public:
         register_test(test_Issue279);
         register_test(test_Issue353);
         register_test(test_Issue494);
+        register_test(test_style);
     }
 
     void test_active_sheet()
@@ -629,6 +630,14 @@ public:
         auto ws = wb.active_sheet();
         xlnt_assert_equals(ws.cell(2, 1).to_string(), "V1.00");
         xlnt_assert_equals(ws.cell(2, 2).to_string(), "V1.00");
+    }
+
+    void test_style()
+    {
+        xlnt::workbook wb;
+        xlnt_assert_equals(wb.has_style("my_custom_style"), false);
+        wb.create_style("my_custom_style");
+        xlnt_assert_equals(wb.has_style("my_custom_style"), true);
     }
 };
 static workbook_test_suite x;


### PR DESCRIPTION
Alternative to coveralls, to overcome some disadvantages/inconveniences of this external service, i.e:
 - loading file details sometimes fails due to gateway timeout
 - for forked pull requests:
   - github comment is not posted on PR
   - coverage report not compared with master branch

HTML reports are generated based on the fully open source genhtml (lcov) tool.

Limit the number of times the benchmarks are run while generating coverage report to speed up CI. Alternative is to disable benchmarks during coverage generation, but this slightly decreases the coverage.

Enabled branch coverage, in addition to the existing line coverage. Disabled coverage reporting for exception branches (for now) as it generates too many (less important) compiler generated branches. 
For more information about exception branches, see https://github.com/gcovr/gcovr/issues/431#issuecomment-705518206