### PR TITLE
Improve documentation when exceptions are thrown (fixes #81)

### DIFF
--- a/include/xlnt/cell/cell.hpp
+++ b/include/xlnt/cell/cell.hpp
@@ -260,6 +260,8 @@ public:
 
     /// <summary>
     /// Returns the relationship of this cell's hyperlink.
+    /// Assumes that this cell has a hyperlink (please call has_hyperlink() to check).
+    /// If this cell does not have a hyperlink, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     class hyperlink hyperlink() const;
 
@@ -336,8 +338,9 @@ public:
     bool has_format() const;
 
     /// <summary>
-    /// Returns the format applied to this cell. If this cell has no
-    /// format, an invalid_attribute exception will be thrown.
+    /// Returns the format applied to this cell.
+    /// Assumes that the format exists (please call has_format() to check).
+    /// If this cell has no format, an invalid_attribute exception will be thrown.
     /// </summary>
     const class format format() const;
 
@@ -428,11 +431,15 @@ public:
 
     /// <summary>
     /// Returns a wrapper pointing to the named style applied to this cell.
+    /// Assumes that the style exists (please call has_style() to check).
+    /// If this cell does not have a style, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     class style style();
 
     /// <summary>
     /// Returns a wrapper pointing to the named style applied to this cell.
+    /// Assumes that the style exists (please call has_style() to check).
+    /// If this cell does not have a style, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     const class style style() const;
 
@@ -460,6 +467,8 @@ public:
 
     /// <summary>
     /// Returns the string representation of the formula applied to this cell.
+    /// Assumes that cell view has a formula (please call has_formula() to check).
+    /// If this cell does not have a formula, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     std::string formula() const;
 
@@ -574,6 +583,8 @@ public:
 
     /// <summary>
     /// Gets the comment applied to this cell.
+    /// Assumes that the comment exists (please call has_comment() to check).
+    /// If this cell does not have a comment, an xlnt::exception will be thrown.
     /// </summary>
     class comment comment();
 
@@ -644,6 +655,8 @@ private:
     /// <summary>
     /// Returns a non-const reference to the format of this cell.
     /// This is for internal use only.
+    /// Assumes that this cell has a format (please call has_format() to check).
+    /// If this cell does not have a format, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     class format modifiable_format();
 

--- a/include/xlnt/cell/hyperlink.hpp
+++ b/include/xlnt/cell/hyperlink.hpp
@@ -52,14 +52,26 @@ public:
 
     bool has_display() const;
     void display(const std::string &value);
+
+    /// Returns the displayed text of the hyperlink.
+    /// Assumes that this hyperlink has a displayed text (please call has_display() to check).
+    /// If this hyperlink does not have a displayed text, an xlnt::invalid_attribute exception will be thrown.
     const std::string &display() const;
 
     bool has_tooltip() const;
     void tooltip(const std::string &value);
+
+    /// Returns the tooltip of the hyperlink.
+    /// Assumes that this hyperlink has a tooltip (please call has_tooltip() to check).
+    /// If this hyperlink does not have a tooltip, an xlnt::invalid_attribute exception will be thrown.
     const std::string &tooltip() const;
 
     bool has_location() const;
     void location(const std::string &value);
+
+    /// Returns the location of the hyperlink.
+    /// Assumes that this hyperlink has a location (please call has_location() to check).
+    /// If this hyperlink does not have a location, an xlnt::invalid_attribute exception will be thrown.
     const std::string &location() const;
 
 private:

--- a/include/xlnt/cell/rich_text.hpp
+++ b/include/xlnt/cell/rich_text.hpp
@@ -119,6 +119,8 @@ public:
 
     /// <summary>
     /// Returns the phonetic properties of this text.
+    /// Assumes that this text has phonetic properties (please call has_phonetic_properties() to check).
+    /// If this text does not have phonetic properties, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     const phonetic_pr &phonetic_properties() const;
 

--- a/include/xlnt/styles/conditional_format.hpp
+++ b/include/xlnt/styles/conditional_format.hpp
@@ -108,7 +108,9 @@ public:
     bool has_border() const;
 
     /// <summary>
-    ///
+    /// Returns the border of this conditional format.
+    /// Assumes that this conditional format has a border (please call has_border() to check).
+    /// If this conditional format does not have a border, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     class border border() const;
 
@@ -123,7 +125,9 @@ public:
     bool has_fill() const;
 
     /// <summary>
-    ///
+    /// Returns the fill of this conditional format.
+    /// Assumes that this conditional format has a fill (please call has_fill() to check).
+    /// If this conditional format does not have a fill, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     class fill fill() const;
 
@@ -138,7 +142,9 @@ public:
     bool has_font() const;
 
     /// <summary>
-    ///
+    /// Returns the font of this conditional format.
+    /// Assumes that this conditional format has a font (please call has_font() to check).
+    /// If this conditional format does not have a font, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     class font font() const;
 

--- a/include/xlnt/styles/font.hpp
+++ b/include/xlnt/styles/font.hpp
@@ -185,6 +185,8 @@ public:
 
     /// <summary>
     /// Returns the color that this font is using.
+    /// Assumes that this font has a color (please call has_color() to check).
+    /// If this font does not have a color, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     xlnt::color color() const;
 
@@ -200,6 +202,8 @@ public:
 
     /// <summary>
     /// Returns the family index for the font.
+    /// Assumes that this font has a family (please call has_family() to check).
+    /// If this font does not have a family, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     std::size_t family() const;
 
@@ -217,6 +221,8 @@ public:
 
     /// <summary>
     /// Returns the charset of the font.
+    /// Assumes that this font has a charset (please call has_charset() to check).
+    /// If this font does not have a charset, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     std::size_t charset() const;
 
@@ -232,6 +238,8 @@ public:
 
     /// <summary>
     /// Returns the scheme of this font.
+    /// Assumes that this font has a scheme (please call has_scheme() to check).
+    /// If this font does not have a scheme, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     const std::string &scheme() const;
 

--- a/include/xlnt/styles/format.hpp
+++ b/include/xlnt/styles/format.hpp
@@ -204,14 +204,16 @@ public:
     format style(const class style &new_style);
 
     /// <summary>
-    /// Returns the style of this format. If it has no style, an invalid_parameter
-    /// exception will be thrown.
+    /// Returns the style of this format.
+    /// Assumes that the style exists (please call has_style() to check).
+    /// If this format has no style, an invalid_attribute exception will be thrown.
     /// </summary>
     class style style();
 
     /// <summary>
-    /// Returns the style of this format. If it has no style, an invalid_parameters
-    /// exception will be thrown.
+    /// Returns the style of this format.
+    /// Assumes that the style exists (please call has_style() to check).
+    /// If this format has no style, an invalid_attribute exception will be thrown.
     /// </summary>
     const class style style() const;
 

--- a/include/xlnt/styles/number_format.hpp
+++ b/include/xlnt/styles/number_format.hpp
@@ -176,8 +176,9 @@ public:
     static bool is_builtin_format(std::size_t builtin_id);
 
     /// <summary>
-    /// Returns the format with the given ID. Thows an invalid_parameter exception
-    /// if builtin_id is not a valid ID.
+    /// Returns the format with the given ID.
+    /// Assumes that the format ID is valid (please call is_builtin_format() to check).
+    /// Thows an invalid_parameter exception if builtin_id is not a valid ID.
     /// </summary>
     static const number_format &from_builtin_id(std::size_t builtin_id);
 
@@ -230,6 +231,8 @@ public:
 
     /// <summary>
     /// Returns the ID of this format.
+    /// Assumes that this format has an ID (please call has_id() to check).
+    /// If this format does not have an ID, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     std::size_t id() const;
 

--- a/include/xlnt/utils/optional.hpp
+++ b/include/xlnt/utils/optional.hpp
@@ -258,7 +258,8 @@ public:
     }
 
     /// <summary>
-    /// Gets the value. If no value has been initialized in this object,
+    /// Gets the value. Assumes that the value exists (please call is_set() to check).
+    /// If no value has been initialized in this object,
     /// an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     T &get()
@@ -272,7 +273,8 @@ public:
     }
 
     /// <summary>
-    /// Gets the value. If no value has been initialized in this object,
+    /// Gets the value. Assumes that the value exists (please call is_set() to check).
+    /// If no value has been initialized in this object,
     /// an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     const T &get() const

--- a/include/xlnt/workbook/streaming_workbook_reader.hpp
+++ b/include/xlnt/workbook/streaming_workbook_reader.hpp
@@ -75,8 +75,11 @@ public:
     bool has_worksheet(const std::string &name);
 
     /// <summary>
-    /// Beings reading of the next worksheet in the workbook and optionally
-    /// returns its title if the last worksheet has not yet been read.
+    /// Beings reading of the next worksheet in the workbook.
+    /// Assumes that this workbook has a worksheet with
+    /// the given name (please call has_worksheet() to check).
+    /// If this workbook does not have a worksheet with the given name,
+    /// an xlnt::exception will be thrown.
     /// </summary>
     void begin_worksheet(const std::string &name);
 

--- a/include/xlnt/workbook/workbook.hpp
+++ b/include/xlnt/workbook/workbook.hpp
@@ -386,6 +386,8 @@ public:
 
     /// <summary>
     /// Returns the value of the given core property.
+    /// Assumes that the specified core_property exists (please call has_core_property() to check).
+    /// If the specified core_property does not exist, an xlnt::exception will be thrown.
     /// </summary>
     variant core_property(xlnt::core_property type) const;
 
@@ -407,6 +409,8 @@ public:
 
     /// <summary>
     /// Returns the value of the given extended property.
+    /// Assumes that the specified extended_property exists (please call has_extended_property() to check).
+    /// If the specified extended_property does not exist, an xlnt::exception will be thrown.
     /// </summary>
     variant extended_property(xlnt::extended_property type) const;
 
@@ -428,6 +432,8 @@ public:
 
     /// <summary>
     /// Returns the value of the given custom property.
+    /// Assumes that the specified custom_property exists (please call has_custom_property() to check).
+    /// If the specified custom_property does not exist, an xlnt::exception will be thrown.
     /// </summary>
     variant custom_property(const std::string &property_name) const;
 
@@ -456,6 +462,8 @@ public:
 
     /// <summary>
     /// Returns the title of this workbook.
+    /// Assumes that this workbook has a title (please call has_title() to check).
+    /// If this workbook has no title, an invalid_attribute exception will be thrown.
     /// </summary>
     std::string title() const;
 
@@ -498,11 +506,15 @@ public:
 
     /// <summary>
     /// Returns the named range with the given name.
+    /// Assumes that the specified named_range exists (please call has_named_range() to check).
+    /// If the specified named_range does not exist, an xlnt::key_not_found exception will be thrown.
     /// </summary>
     class range named_range(const std::string &name);
 
     /// <summary>
     /// Deletes the named range with the given name.
+    /// Assumes that the specified named_range exists (please call has_named_range() to check).
+    /// If the specified named_range does not exist, an xlnt::key_not_found exception will be thrown.
     /// </summary>
     void remove_named_range(const std::string &name);
 
@@ -717,6 +729,8 @@ public:
 
     /// <summary>
     /// Returns the view.
+    /// Assumes that the view exists (please call has_view() to check).
+    /// If the view does not exist, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     workbook_view view() const;
 
@@ -734,6 +748,8 @@ public:
 
     /// <summary>
     /// Returns the code name that was set for this workbook.
+    /// Assumes that the code_name exists (please call has_code_name() to check).
+    /// If the code_name does not exist, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     std::string code_name() const;
 
@@ -749,21 +765,29 @@ public:
 
     /// <summary>
     /// Returns the AppName workbook file property.
+    /// Assumes that this workbook has a file version (please call has_file_version() to check).
+    /// If this workbook has no file version, an invalid_attribute exception will be thrown.
     /// </summary>
     std::string app_name() const;
 
     /// <summary>
     /// Returns the LastEdited workbook file property.
+    /// Assumes that this workbook has a file version (please call has_file_version() to check).
+    /// If this workbook has no file version, an invalid_attribute exception will be thrown.
     /// </summary>
     std::size_t last_edited() const;
 
     /// <summary>
     /// Returns the LowestEdited workbook file property.
+    /// Assumes that this workbook has a file version (please call has_file_version() to check).
+    /// If this workbook has no file version, an invalid_attribute exception will be thrown.
     /// </summary>
     std::size_t lowest_edited() const;
 
     /// <summary>
     /// Returns the RupBuild workbook file property.
+    /// Assumes that this workbook has a file version (please call has_file_version() to check).
+    /// If this workbook has no file version, an invalid_attribute exception will be thrown.
     /// </summary>
     std::size_t rup_build() const;
 
@@ -776,6 +800,8 @@ public:
 
     /// <summary>
     /// Returns a const reference to this workbook's theme.
+    /// Assumes that this workbook has a theme (please call has_theme() to check).
+    /// If this workbook has no theme, an invalid_attribute exception will be thrown.
     /// </summary>
     const xlnt::theme &theme() const;
 
@@ -935,6 +961,8 @@ public:
 
     /// <summary>
     /// Returns the calculation properties used in this workbook.
+    /// Assumes that this workbook has calculation properties (please call has_calculation_properties() to check).
+    /// If this workbook has no calculation properties, an invalid_attribute exception will be thrown.
     /// </summary>
     class calculation_properties calculation_properties() const;
 

--- a/include/xlnt/worksheet/page_setup.hpp
+++ b/include/xlnt/worksheet/page_setup.hpp
@@ -112,6 +112,8 @@ public:
 
     /// <summary>
     /// Returns the paper size which should be used to print the worksheet using this page setup.
+    /// Assumes that this page setup has a paper size (please call has_paper_size() to check).
+    /// If this workbook has no paper size, an invalid_attribute exception will be thrown.
     /// </summary>
     xlnt::paper_size paper_size() const;
 
@@ -162,6 +164,8 @@ public:
 
     /// <summary>
     /// Returns the factor by which the page should be scaled during printing.
+    /// Assumes that this page setup has a scale (please call has_scale() to check).
+    /// If this workbook has no scale, an invalid_attribute exception will be thrown.
     /// </summary>
     double scale() const;
 

--- a/include/xlnt/worksheet/phonetic_pr.hpp
+++ b/include/xlnt/worksheet/phonetic_pr.hpp
@@ -100,6 +100,8 @@ public:
 
     /// <summary>
     /// returns the phonetic type
+    /// Assumes that this phonetic_pr has a type (please call has_type() to check).
+    /// If this phonetic_pr has no type, an invalid_attribute exception will be thrown.
     /// </summary>
     phonetic_type type() const;
 
@@ -115,6 +117,8 @@ public:
 
     /// <summary>
     /// get the alignment
+    /// Assumes that this phonetic_pr has an alignment (please call has_alignment() to check).
+    /// If this phonetic_pr has no alignment, an invalid_attribute exception will be thrown.
     /// </summary>
     align alignment() const;
 

--- a/include/xlnt/worksheet/selection.hpp
+++ b/include/xlnt/worksheet/selection.hpp
@@ -74,6 +74,8 @@ public:
 
     /// <summary>
     /// Returns the cell reference of the active cell.
+    /// Assumes that this selection has an active cell (please call has_active_cell() to check).
+    /// If this selection does not have an active cell, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     cell_reference active_cell() const
     {
@@ -100,6 +102,8 @@ public:
     /// Returns the range encompassed by this selection.
     /// If the range contains multiple (non-contiguous) regions, the first range is returned.
     /// Use sqrefs to obtain the full selection.
+    /// Assumes that at least one region exists (please call has_sqref() to check).
+    /// If there are no regions, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     /// <deprecated>
     /// Use sqrefs instead.

--- a/include/xlnt/worksheet/sheet_view.hpp
+++ b/include/xlnt/worksheet/sheet_view.hpp
@@ -75,6 +75,8 @@ public:
 
     /// <summary>
     /// Returns a reference to this view's pane.
+    /// Assumes that this view has a pane (please call has_pane() to check).
+    /// If this view does not have a pane, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     struct pane &pane()
     {
@@ -83,6 +85,8 @@ public:
 
     /// <summary>
     /// Returns a reference to this view's pane.
+    /// Assumes that this view has a pane (please call has_pane() to check).
+    /// If this view does not have a pane, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     const struct pane &pane() const
     {
@@ -211,6 +215,8 @@ public:
 
     /// <summary>
     /// Returns the top left cell of this view.
+    /// Assumes that this view has a top left (please call has_top_left_cell() to check).
+    /// If this view does not have a top left cell, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     cell_reference top_left_cell() const
     {

--- a/include/xlnt/worksheet/worksheet.hpp
+++ b/include/xlnt/worksheet/worksheet.hpp
@@ -149,6 +149,8 @@ public:
 
     /// <summary>
     /// Returns the top left corner of the region above and to the left of which panes are frozen.
+    /// Assumes that this sheet has frozen panes (please call has_frozen_panes() to check).
+    /// If this sheet does not have frozen panes, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     cell_reference frozen_panes() const;
 
@@ -372,19 +374,23 @@ public:
     bool has_named_range(const std::string &name) const;
 
     /// <summary>
-    /// Returns the named range with the given name. Throws key_not_found
-    /// exception if the named range doesn't exist.
+    /// Returns the named range with the given name.
+    /// Assumes that the named range exists (please call has_named_range() to check).
+    /// Throws key_not_found exception if the named range doesn't exist.
     /// </summary>
     class range named_range(const std::string &name);
 
     /// <summary>
-    /// Returns the named range with the given name. Throws key_not_found
-    /// exception if the named range doesn't exist.
+    /// Returns the named range with the given name.
+    /// Assumes that the named range exists (please call has_named_range() to check).
+    /// Throws key_not_found exception if the named range doesn't exist.
     /// </summary>
     const class range named_range(const std::string &name) const;
 
     /// <summary>
     /// Removes a named range with the given name.
+    /// Assumes that the named range exists (please call has_named_range() to check).
+    /// Throws key_not_found exception if the named range doesn't exist.
     /// </summary>
     void remove_named_range(const std::string &name);
 
@@ -523,6 +529,8 @@ public:
 
     /// <summary>
     /// Returns the page setup for this sheet.
+    /// Assumes that this sheet has a page setup (please call has_page_setup() to check).
+    /// If this sheet does not have a page setup, an xlnt::invalid_attribute exception will be thrown.
     /// </summary>
     xlnt::page_setup page_setup() const;
 
@@ -538,6 +546,8 @@ public:
 
     /// <summary>
     /// Returns the margins of this sheet.
+    /// Assumes that this sheet has page margins (please call has_page_margins() to check).
+    /// If this sheet has no page margins, an invalid_attribute exception will be thrown.
     /// </summary>
     xlnt::page_margins page_margins() const;
 
@@ -550,6 +560,8 @@ public:
 
     /// <summary>
     /// Returns the current auto-filter of this sheet.
+    /// Assumes that this sheet has an auto-filter (please call has_auto_filter() to check).
+    /// If this sheet has no auto-filter, an invalid_attribute exception will be thrown.
     /// </summary>
     range_reference auto_filter() const;
 
@@ -591,6 +603,8 @@ public:
 
     /// <summary>
     /// Returns the phonetic properties of this sheet.
+    /// Assumes that this sheet has phonetic properties (please call has_phonetic_properties() to check).
+    /// If this sheet has no phonetic properties, an invalid_attribute exception will be thrown.
     /// </summary>
     const phonetic_pr &phonetic_properties() const;
 
@@ -606,6 +620,8 @@ public:
 
     /// <summary>
     /// Returns the header/footer of this sheet.
+    /// Assumes that this sheet has a header/footer (please call has_header_footer() to check).
+    /// If this sheet has no header/footer, an invalid_attribute exception will be thrown.
     /// </summary>
     class header_footer header_footer() const;
 
@@ -696,6 +712,8 @@ public:
 
     /// <summary>
     /// Returns the print area defined for this sheet.
+    /// Assumes that this sheet has a print area (please call has_print_area() to check).
+    /// If this sheet has no print area, an invalid_attribute exception will be thrown.
     /// </summary>
     range_reference print_area() const;
 
@@ -731,6 +749,8 @@ public:
 
     /// <summary>
     /// Returns the active cell on the default worksheet view.
+    /// Assumes that this worksheet has an active cell (please call has_active_cell() to check).
+    /// If this worksheet does not have an active cell, an xlnt::exception will be thrown.
     /// </summary>
     cell_reference active_cell() const;
 


### PR DESCRIPTION
Many of our public functions did not explain properly the cases where exceptions could be thrown, leading to unexpected crashes. This PR improves documentation to prevent such issues.

See https://github.com/xlnt-community/xlnt/issues/81 for more details.

Fixes https://github.com/xlnt-community/xlnt/issues/81