### PR TITLE
Fix exception thrown by worksheet::cell for non-existing cell

### DIFF
--- a/source/worksheet/worksheet.cpp
+++ b/source/worksheet/worksheet.cpp
@@ -397,7 +397,12 @@ cell worksheet::cell(const cell_reference &reference)
 
 const cell worksheet::cell(const cell_reference &reference) const
 {
-    return xlnt::cell(&d_->cell_map_.at(reference));
+    const auto match = d_->cell_map_.find(reference);
+    if (match == d_->cell_map_.end())
+    {
+        throw xlnt::invalid_parameter("Requested cell doesn't exist.");
+    }
+    return xlnt::cell(&match->second);
 }
 
 cell worksheet::cell(xlnt::column_t column, row_t row)

--- a/tests/worksheet/worksheet_test_suite.cpp
+++ b/tests/worksheet/worksheet_test_suite.cpp
@@ -115,6 +115,7 @@ public:
         register_test(test_issue_5_empty_bottom_rows);
         register_test(test_issue_18_defined_name_with_workbook_scope);
         register_test(test_non_contiguous_selection);
+        register_test(test_throw_empty_cell);
     }
 
     void test_new_worksheet()
@@ -1712,6 +1713,14 @@ public:
         xlnt_assert_equals(s.sqrefs()[2], "D4:D5");
         xlnt_assert_equals(s.sqrefs()[3], "E6:F6");
         xlnt_assert_differs(s.sqrefs()[0], "B1");
+    }
+
+    void test_throw_empty_cell()
+    {
+        xlnt::workbook wb;
+        const auto ws = wb.active_sheet();
+
+        xlnt_assert_throws(ws.cell("X10"), xlnt::invalid_parameter);
     }
 };
 


### PR DESCRIPTION
According to the docs xlnt::invalid_parameter should be thrown if cell doesn't exist.
Previously, a std::out_of_range exception was thrown.