### PR TITLE
Improve iterator checks when searching elements in containers

### DIFF
--- a/source/detail/header_footer/header_footer_code.cpp
+++ b/source/detail/header_footer/header_footer_code.cpp
@@ -76,6 +76,7 @@ std::array<xlnt::optional<xlnt::rich_text>, 3> decode_header_footer(const std::s
 
     std::vector<hf_token> tokens;
     std::size_t position = 0;
+    const std::string numbers("0123456789");
 
     while (position < hf_string.size())
     {
@@ -123,7 +124,7 @@ std::array<xlnt::optional<xlnt::rich_text>, 3> decode_header_footer(const std::s
             {
                 token.code = hf_code::total_page_number;
             }
-            else if (std::string("0123456789").find(hf_string[position + 1]) != std::string::npos)
+            else if (numbers.find(hf_string[position + 1]) != std::string::npos)
             {
                 token.code = hf_code::font_size;
                 next_position = hf_string.find_first_not_of("0123456789", position + 1);
@@ -220,7 +221,12 @@ std::array<xlnt::optional<xlnt::rich_text>, 3> decode_header_footer(const std::s
 
     const auto parse_section = [&tokens, &result](hf_code code) {
         std::vector<hf_code> end_codes{hf_code::left_section, hf_code::center_section, hf_code::right_section};
-        end_codes.erase(std::find(end_codes.begin(), end_codes.end(), code));
+        auto it = std::find(end_codes.begin(), end_codes.end(), code);
+        if (it == end_codes.end())
+        {
+            return;
+        }
+        end_codes.erase(it);
 
         std::size_t start_index = 0;
 

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -534,7 +534,7 @@ void read_defined_names(worksheet ws, std::vector<defined_name> defined_names)
         }
         else if (name.name == "_xlnm._FilterDatabase")
         {
-            auto i = name.value.find("!");
+            auto i = name.value.find('!');
             auto ref = name.value.substr(i + 1);
             if (is_valid_reference(ref))
             {
@@ -543,7 +543,7 @@ void read_defined_names(worksheet ws, std::vector<defined_name> defined_names)
         }
         else if (name.name == "_xlnm.Print_Area")
         {
-            auto i = name.value.find("!");
+            auto i = name.value.find('!');
             auto ref = name.value.substr(i + 1);
             if (is_valid_reference(ref))
             {
@@ -563,11 +563,16 @@ std::string xlsx_consumer::read_worksheet_begin(const std::string &rel_id)
     array_formulae_.clear();
     shared_formulae_.clear();
 
-    auto title = std::find_if(target_.d_->sheet_title_rel_id_map_.begin(),
+    auto it_title = std::find_if(target_.d_->sheet_title_rel_id_map_.begin(),
         target_.d_->sheet_title_rel_id_map_.end(),
-        [&](const std::pair<std::string, std::string> &p) {
+        [&rel_id](const std::pair<std::string, std::string> &p) {
             return p.second == rel_id;
-        })->first;
+        });
+    if (it_title == target_.d_->sheet_title_rel_id_map_.end())
+    {
+        throw xlnt::key_not_found(rel_id);
+    }
+    const auto &title = it_title->first;
 
     auto ws = worksheet(current_worksheet_);
 
@@ -836,7 +841,7 @@ std::string xlsx_consumer::read_worksheet_begin(const std::string &rel_id)
 #endif
 
                 // avoid uninitialised warnings in GCC by using a lambda to make the conditional initialisation
-                optional<double> width = [this](xml::parser &p) -> xlnt::optional<double> {
+                optional<double> width = [](xml::parser &p) -> xlnt::optional<double> {
                     if (p.attribute_present("width"))
                     {
                         return (xlnt::detail::deserialise(p.attribute("width")) * 7 - 5) / 7;
@@ -2313,11 +2318,16 @@ void xlsx_consumer::read_office_document(const std::string &content_type) // CT_
 
     for (auto worksheet_rel : manifest().relationships(workbook_path, relationship_type::worksheet))
     {
-        auto title = std::find_if(target_.d_->sheet_title_rel_id_map_.begin(),
+        auto it_title = std::find_if(target_.d_->sheet_title_rel_id_map_.begin(),
             target_.d_->sheet_title_rel_id_map_.end(),
-            [&](const std::pair<std::string, std::string> &p) {
+            [&worksheet_rel](const std::pair<std::string, std::string> &p) {
                 return p.second == worksheet_rel.id();
-            })->first;
+            });
+        if (it_title == target_.d_->sheet_title_rel_id_map_.end())
+        {
+            throw xlnt::key_not_found(worksheet_rel.id());
+        }
+        const auto &title = it_title->first;
 
         auto id = sheet_title_id_map_[title];
         auto index = sheet_title_index_map_[title];

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -1730,11 +1730,6 @@ void xlsx_consumer::read_stylesheet (const std::string& xml)
     parser_ = nullptr;
 }
 
-std::string xlsx_consumer::read_worksheet_begin_TEST(const std::string &rel_id)
-{
-    return read_worksheet_begin(rel_id);
-}
-
 void xlsx_consumer::read_part(const std::vector<relationship> &rel_chain)
 {
     const auto &manifest = target_.manifest();

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -1730,6 +1730,11 @@ void xlsx_consumer::read_stylesheet (const std::string& xml)
     parser_ = nullptr;
 }
 
+std::string xlsx_consumer::read_worksheet_begin_TEST(const std::string &rel_id)
+{
+    return read_worksheet_begin(rel_id);
+}
+
 void xlsx_consumer::read_part(const std::vector<relationship> &rel_chain)
 {
     const auto &manifest = target_.manifest();

--- a/source/detail/serialization/xlsx_consumer.hpp
+++ b/source/detail/serialization/xlsx_consumer.hpp
@@ -84,6 +84,7 @@ public:
 
     // For unit testing purpose only
     void read_stylesheet (const std::string& xml);
+    std::string read_worksheet_begin_TEST(const std::string &rel_id);
 
 private:
     friend class xlnt::streaming_workbook_reader;

--- a/source/detail/serialization/xlsx_consumer.hpp
+++ b/source/detail/serialization/xlsx_consumer.hpp
@@ -41,6 +41,9 @@
   #include <string_view>
 #endif
 
+
+class serialization_test_suite;
+
 namespace xlnt {
 
 class cell;
@@ -70,6 +73,8 @@ struct worksheet_impl;
 class XLNT_API_INTERNAL xlsx_consumer
 {
 public:
+    friend class ::serialization_test_suite;
+
 	xlsx_consumer(workbook &destination);
 
 	~xlsx_consumer();
@@ -84,7 +89,6 @@ public:
 
     // For unit testing purpose only
     void read_stylesheet (const std::string& xml);
-    std::string read_worksheet_begin_TEST(const std::string &rel_id);
 
 private:
     friend class xlnt::streaming_workbook_reader;

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2294,10 +2294,15 @@ void xlsx_producer::write_worksheet(const relationship &rel)
     auto worksheet_part = rel.source().path().parent().append(rel.target().path());
     auto worksheet_rels = source_.manifest().relationships(worksheet_part);
 
-    auto title = std::find_if(source_.d_->sheet_title_rel_id_map_.begin(), source_.d_->sheet_title_rel_id_map_.end(),
-        [&](const std::pair<std::string, std::string> &p) {
+    auto it_title = std::find_if(source_.d_->sheet_title_rel_id_map_.begin(), source_.d_->sheet_title_rel_id_map_.end(),
+        [&rel](const std::pair<std::string, std::string> &p) {
             return p.second == rel.id();
-        })->first;
+        });
+    if (it_title == source_.d_->sheet_title_rel_id_map_.end())
+    {
+        throw xlnt::key_not_found(rel.id());
+    }
+    const auto &title = it_title->first;
 
     auto ws = source_.sheet_by_title(title);
 
@@ -3514,7 +3519,11 @@ void xlsx_producer::write_relationships(const std::vector<xlnt::relationship> &r
     {
         auto rel_iter = std::find_if(relationships.begin(), relationships.end(),
             [&i](const relationship &r) { return r.id() == "rId" + std::to_string(i); });
-        auto relationship = *rel_iter;
+        if (rel_iter == relationships.end())
+        {
+            throw xlnt::key_not_found("rId" + std::to_string(i));
+        }
+        const auto &relationship = *rel_iter;
 
         write_start_element(xmlns, "Relationship");
 

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2284,11 +2284,6 @@ void xlsx_producer::write_volatile_dependencies(const relationship & /*rel*/)
     write_end_element(constants::ns("spreadsheetml"), "volTypes");
 }
 
-void xlsx_producer::write_worksheet_TEST(const relationship &rel)
-{
-    write_worksheet(rel);
-}
-
 void xlsx_producer::write_worksheet(const relationship &rel)
 {
     static const auto &xmlns = constants::ns("spreadsheetml");

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2284,15 +2284,17 @@ void xlsx_producer::write_volatile_dependencies(const relationship & /*rel*/)
     write_end_element(constants::ns("spreadsheetml"), "volTypes");
 }
 
+void xlsx_producer::write_worksheet_TEST(const relationship &rel)
+{
+    write_worksheet(rel);
+}
+
 void xlsx_producer::write_worksheet(const relationship &rel)
 {
     static const auto &xmlns = constants::ns("spreadsheetml");
     static const auto &xmlns_r = constants::ns("r");
     static const auto &xmlns_mc = constants::ns("mc");
     static const auto &xmlns_x14ac = constants::ns("x14ac");
-
-    auto worksheet_part = rel.source().path().parent().append(rel.target().path());
-    auto worksheet_rels = source_.manifest().relationships(worksheet_part);
 
     auto it_title = std::find_if(source_.d_->sheet_title_rel_id_map_.begin(), source_.d_->sheet_title_rel_id_map_.end(),
         [&rel](const std::pair<std::string, std::string> &p) {
@@ -2303,6 +2305,9 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         throw xlnt::key_not_found(rel.id());
     }
     const auto &title = it_title->first;
+
+    auto worksheet_part = rel.source().path().parent().append(rel.target().path());
+    auto worksheet_rels = source_.manifest().relationships(worksheet_part);
 
     auto ws = source_.sheet_by_title(title);
 

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -68,7 +68,7 @@ struct worksheet_impl;
 /// <summary>
 /// Handles writing a workbook into an XLSX file.
 /// </summary>
-class xlsx_producer
+class XLNT_API_INTERNAL xlsx_producer
 {
 public:
 	xlsx_producer(const workbook &target);
@@ -82,6 +82,9 @@ public:
 #if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     void write(std::ostream &destination, std::u8string_view password);
 #endif
+
+    // For unit testing purpose only
+    void write_worksheet_TEST(const relationship &rel);
 
 private:
     friend class xlnt::streaming_workbook_writer;

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -39,6 +39,9 @@
   #include <string_view>
 #endif
 
+
+class serialization_test_suite;
+
 namespace xml {
 class serializer;
 } // namespace xml
@@ -71,6 +74,8 @@ struct worksheet_impl;
 class XLNT_API_INTERNAL xlsx_producer
 {
 public:
+    friend class ::serialization_test_suite;
+
 	xlsx_producer(const workbook &target);
 
     ~xlsx_producer();
@@ -82,9 +87,6 @@ public:
 #if XLNT_HAS_FEATURE(U8_STRING_VIEW)
     void write(std::ostream &destination, std::u8string_view password);
 #endif
-
-    // For unit testing purpose only
-    void write_worksheet_TEST(const relationship &rel);
 
 private:
     friend class xlnt::streaming_workbook_writer;

--- a/source/packaging/ext_list.cpp
+++ b/source/packaging/ext_list.cpp
@@ -1,4 +1,5 @@
 #include <xlnt/packaging/ext_list.hpp>
+#include <xlnt/utils/exceptions.hpp>
 #include <algorithm>
 
 #include <detail/external/include_libstudxml.hpp>
@@ -123,8 +124,13 @@ bool ext_list::has_extension(const uri &extension_uri) const
 
 const ext_list::ext &ext_list::extension(const uri &extension_uri) const
 {
-    return *std::find_if(extensions_.begin(), extensions_.end(),
+    auto it = std::find_if(extensions_.begin(), extensions_.end(),
         [&extension_uri](const ext &ext) { return extension_uri == ext.extension_ID_; });
+    if (it == extensions_.end())
+    {
+        throw xlnt::key_not_found(extension_uri.to_string());
+    }
+    return *it;
 }
 
 const std::vector<ext_list::ext> &ext_list::extensions() const

--- a/source/packaging/manifest.cpp
+++ b/source/packaging/manifest.cpp
@@ -127,16 +127,19 @@ relationship manifest::relationship(const path &part, relationship_type type) co
 
 std::vector<xlnt::relationship> manifest::relationships(const path &part, relationship_type type) const
 {
+    auto rels = relationships_.find(part);
+    if (rels == relationships_.end())
+    {
+        return {};
+    }
+
     std::vector<xlnt::relationship> matches;
 
-    if (has_relationship(part, type))
+    for (const auto &rel : rels->second)
     {
-        for (const auto &rel : relationships_.at(part))
+        if (rel.second.type() == type)
         {
-            if (rel.second.type() == type)
-            {
-                matches.push_back(rel.second);
-            }
+            matches.push_back(rel.second);
         }
     }
 

--- a/source/workbook/workbook.cpp
+++ b/source/workbook/workbook.cpp
@@ -2141,6 +2141,11 @@ void workbook::reorder_relationships()
         auto rel_it = std::find_if(rel_copy.begin(), rel_copy.end(),
             [&](const relationship &rel) { return rel.id() == worksheet_rel_ids[index]; });
 
+        if (rel_it == rel_copy.end())
+        {
+            throw xlnt::key_not_found(worksheet_rel_ids[index]);
+        }
+
         std::string rel_id = new_id();
         d_->sheet_title_rel_id_map_.at(titles[index - 1]) = rel_id; // update title -> relation mapping
         manifest().register_relationship(relationship(rel_id, rel_it->type(),

--- a/tests/internal/serialization_test_suite.cpp
+++ b/tests/internal/serialization_test_suite.cpp
@@ -29,6 +29,7 @@
 #include <helpers/test_suite.hpp>
 #include <helpers/internal/xml_helper.hpp>
 #include <detail/serialization/xlsx_consumer.hpp>
+#include <detail/serialization/xlsx_producer.hpp>
 #include <xlnt/internal/features.hpp>
 
 #if XLNT_HAS_INCLUDE(<string_view>) && XLNT_HAS_FEATURE(U8_STRING_VIEW)
@@ -55,6 +56,8 @@ public:
         register_test(test_read_unicode_filename);
         register_test(test_write_unicode_filename);
         register_test(test_comments);
+        register_test(test_invalid_worksheet_title);
+        register_test(test_write_invalid_relationship);
         register_test(test_read_hyperlink);
         register_test(test_read_formulae);
         register_test(test_read_headers_and_footers);
@@ -430,6 +433,20 @@ public:
         xlnt_assert_equals(sheet2.cell("A1").value<std::string>(), "Sheet2!A1");
         xlnt_assert_equals(sheet2.cell("A1").comment().plain_text(), "Sheet2 comment");
         xlnt_assert_equals(sheet2.cell("A1").comment().author(), "Microsoft Office User");
+    }
+
+    void test_invalid_worksheet_title()
+    {
+        xlnt::workbook wb;
+        xlnt::detail::xlsx_consumer consumer(wb);
+        xlnt_assert_throws(consumer.read_worksheet_begin_TEST("TEST_INVALID"), xlnt::key_not_found);
+    }
+
+    void test_write_invalid_relationship()
+    {
+        xlnt::workbook wb;
+        xlnt::detail::xlsx_producer producer(wb);
+        xlnt_assert_throws(producer.write_worksheet_TEST(xlnt::relationship{}), xlnt::key_not_found);
     }
 
     void test_read_hyperlink()

--- a/tests/internal/serialization_test_suite.cpp
+++ b/tests/internal/serialization_test_suite.cpp
@@ -439,14 +439,14 @@ public:
     {
         xlnt::workbook wb;
         xlnt::detail::xlsx_consumer consumer(wb);
-        xlnt_assert_throws(consumer.read_worksheet_begin_TEST("TEST_INVALID"), xlnt::key_not_found);
+        xlnt_assert_throws(consumer.read_worksheet_begin("TEST_INVALID"), xlnt::key_not_found);
     }
 
     void test_write_invalid_relationship()
     {
         xlnt::workbook wb;
         xlnt::detail::xlsx_producer producer(wb);
-        xlnt_assert_throws(producer.write_worksheet_TEST(xlnt::relationship{}), xlnt::key_not_found);
+        xlnt_assert_throws(producer.write_worksheet(xlnt::relationship{}), xlnt::key_not_found);
     }
 
     void test_read_hyperlink()

--- a/tests/packaging/ext_list_test_suite.cpp
+++ b/tests/packaging/ext_list_test_suite.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 xlnt-community
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE
+//
+// @license: http://www.opensource.org/licenses/mit-license.php
+// @author: see AUTHORS file
+
+#include <helpers/test_suite.hpp>
+
+#include <xlnt/packaging/ext_list.hpp>
+
+class ext_list_test_suite : public test_suite
+{
+public:
+    ext_list_test_suite()
+    {
+        register_test(test_invalid_extension);
+    }
+
+    void test_invalid_extension()
+    {
+        xlnt::ext_list list;
+        xlnt_assert_throws(list.extension({}), xlnt::key_not_found);
+    }
+};
+
+static ext_list_test_suite x;

--- a/tests/packaging/uri_test_suite.cpp
+++ b/tests/packaging/uri_test_suite.cpp
@@ -1,5 +1,4 @@
-// Copyright (c) 2014-2022 Thomas Fussell
-// Copyright (c) 2024-2026 xlnt-community
+// Copyright (c) 2026 xlnt-community
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR improves checks when searching elements in containers, when calling `find()`, `std::find()` and `std::find_if()`. Instead of causing uncontrolled crashes (like segfaults), XLNT exceptions will now be thrown instead.

Fixes the segfault described in https://github.com/xlnt-community/xlnt/issues/140