### PR TITLE
Coalesce consecutive columns that all have identical properties

### DIFF
--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2565,9 +2565,18 @@ void xlsx_producer::write_worksheet(const relationship &rel)
 
         const auto &props = ws.column_properties(column);
 
+        // Coalesce a run of consecutive columns that all have identical column_properties
+        // into a single <col min max> range, instead of writing one <col> element per column.
+        auto range_end = column;
+        while (range_end + 1 <= last_column && ws.has_column_properties(range_end + 1)
+            && ws.column_properties(range_end + 1) == props)
+        {
+            ++range_end;
+        }
+
         write_start_element(xmlns, "col");
         write_attribute("min", column.index);
-        write_attribute("max", column.index);
+        write_attribute("max", range_end.index);
 
         if (props.width.is_set())
         {
@@ -2596,6 +2605,8 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         }
 
         write_end_element(xmlns, "col");
+
+        column = range_end;
     }
 
     if (has_column_properties)

--- a/tests/helpers/internal/xml_helper.hpp
+++ b/tests/helpers/internal/xml_helper.hpp
@@ -414,4 +414,39 @@ public:
 
         return match;
     }
+
+    static void skip_element(xml::parser& parser)
+    {
+        int depth = 1;
+
+        skip_attributes(parser);
+
+        while (depth > 0)
+        {
+            switch (parser.next())
+            {
+            case xml::parser::start_element: skip_attributes(parser); ++depth; break;
+            case xml::parser::end_element: --depth; break;
+            default: break;
+            }
+        }
+    }
+
+    static void skip_attributes(xml::parser& parser)
+    {
+        parser.attribute_map();
+    }
+
+    static bool find_element(xml::parser& parser, const std::string& element)
+    {
+        while(parser.next() == xml::parser::start_element)
+        {
+            if (parser.name() == element)
+                return true;
+            else
+                xml_helper::skip_element(parser);
+        }
+
+        return false;
+    }
 };

--- a/tests/internal/serialization_test_suite.cpp
+++ b/tests/internal/serialization_test_suite.cpp
@@ -91,8 +91,9 @@ public:
 #endif
         register_test(test_Issue6_google_missing_workbookView);
         register_test(test_non_contiguous_selection);
-        register_test(test_Issue41_empty_fill)
-        register_test(test_value_with_default)
+        register_test(test_Issue41_empty_fill);
+        register_test(test_value_with_default);
+        register_test(test_coalesce_column_properties);
     }
 
     bool workbook_matches_file(xlnt::workbook &wb, const xlnt::path &file)
@@ -982,6 +983,38 @@ R"TEST(<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
             xlnt_assert_equals(wb2.active_sheet().page_setup().scale(), scale);
         }
+    }
+
+    void test_coalesce_column_properties()
+    {
+        xlnt::workbook wb;
+        auto ws = wb.active_sheet();
+
+        ws.column_properties(1).width = 10;
+        ws.column_properties(2).width = 10;
+        ws.column_properties(3).width = 15;
+
+        std::vector<std::uint8_t> data;
+        wb.save(data);
+
+        xlnt::detail::vector_istreambuf buffer(data);
+        std::istream stream(&buffer);
+        xlnt::detail::izstream archive(stream);
+
+        std::unique_ptr<std::streambuf> ws_buffer = archive.open(xlnt::path("xl/worksheets/sheet1.xml"));
+        std::istream ws_stream(ws_buffer.get());
+        xml::parser parser(ws_stream, "sheet1.xml");
+
+        xlnt_assert (xml_helper::find_element(parser, "worksheet"));
+        xlnt_assert (xml_helper::find_element(parser, "cols"));
+        xlnt_assert (xml_helper::find_element(parser, "col"));
+        xlnt_assert_equals (parser.attribute<xlnt::column_t::index_t>("min"), 1);
+        xlnt_assert_equals (parser.attribute<xlnt::column_t::index_t>("max"), 2);
+        xml_helper::skip_element(parser);
+
+        xlnt_assert (xml_helper::find_element(parser, "col"));
+        xlnt_assert_equals (parser.attribute<xlnt::column_t::index_t>("min"), 3);
+        xlnt_assert_equals (parser.attribute<xlnt::column_t::index_t>("max"), 3);
     }
 };
 


### PR DESCRIPTION
We want to use xlnt as a fallback to a legacy Excel export that invokes Excel via the OLE interface.
We compared the created files and identified a slight but significant difference, which we could trace back to the xlnt implementation.
We load a template and fill several columns with data.
The OLE export generated a file, which initially shows only two columns after the column range with exported data. Only when manually scrolling to the right, further new empty columns appear.
The xlnt export generated a file, which already contains many more empty columns, all with identical properties. The file size is also significantly larger than the originally exported file.
With a little help from claude code we could identify the problem in xlnt, where consecutive columns with identical properties at the end of the file are not coalesced.